### PR TITLE
chore: wire up as standalone repo (deps + import fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build / cache
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+
+# Benchmark outputs (regenerable, large)
+results/
+*.png
+plots/output/
+
+# Local data dumps
+*.npz
+*.json.gz
+.cache/
+.jax_cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+MIT License
+
+Copyright (c) 2026 zazabap
+
+Portions of this project are a Python port of ParametricDFT.jl
+(https://github.com/nzy1997/ParametricDFT.jl), Copyright (c) 2025 nzy1997,
+originally released under the MIT License.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/harness.py
+++ b/harness.py
@@ -23,7 +23,7 @@ import numpy as np
 # It MUST come before any `import jax` / `import jax.numpy` so that
 # x64 is set before JAX caches its dtype defaults.
 import pdft
-from pdft.io.serialize import _format_float_julia_like
+from pdft.io import format_float_julia_like as _format_float_julia_like
 
 import jax  # noqa: E402
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pdft-benchmarks"
+version = "0.1.0"
+description = "Benchmarks for pdft: GPU runs on quickdraw / DIV2K, rate-distortion vs DCT/JPEG baselines, paper figures."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { file = "LICENSE" }
+authors = [{ name = "zazabap" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Physics",
+]
+dependencies = [
+    "pdft>=0.2.0",
+    "numpy>=1.26",
+    "scipy>=1.11",
+    "matplotlib>=3.7",
+    "pillow>=10.0",
+    "tqdm>=4.65",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.6",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["plots"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"


### PR DESCRIPTION
## Summary
First PR after the history extraction. Makes this repo installable on its own and pinned against the just-cut **pdft v0.2.0**.

## What changed
- **pyproject.toml** — declares `pdft >= 0.2.0` plus benchmark deps (numpy, scipy, matplotlib, pillow, tqdm).
- **harness.py** — switches to the new public name:
  ```diff
  - from pdft.io.serialize import _format_float_julia_like
  + from pdft.io import format_float_julia_like as _format_float_julia_like
  ```
  The local alias keeps the rest of `harness.py` unchanged.
- **.gitignore** — ignores `__pycache__/`, `results/` (large regenerable outputs), and other dumps.
- **LICENSE** — copied from upstream `pdft` repo.

## Test plan
- [ ] `pip install -e .[dev]` resolves without conflicts
- [ ] `python -c "import harness"` succeeds
- [ ] At least one benchmark (e.g. `python run_div2k_8q.py --help`) runs to its `--help` output
- [ ] Reproduce a previously-recorded result and diff against `metrics.json`