### PR TITLE
Add blocked_8 / rich_8 / real_rich_8 factories (8×8 trained blocks)

### DIFF
--- a/src/pdft_benchmarks/bases.py
+++ b/src/pdft_benchmarks/bases.py
@@ -25,16 +25,29 @@ import pdft
 BasisFactory = Callable[..., Any]   # (m, n, seed=0) -> AbstractSparseBasis
 
 
-def _blocked(m: int, n: int, seed: int, inner_cls):
+def _blocked(m: int, n: int, seed: int, inner_cls,
+             inner_m: int | None = None, inner_n: int | None = None):
     # Asymmetric split: inner gets the larger half on odd dims so
     # inner_m + block_log_m == m exactly. At even m this matches the
     # previous symmetric split (m//2 + m//2 == m). At odd m (e.g.
     # QuickDraw m=5) it gives inner_m=3 + block_log_m=2 instead of
     # 2+2=4 (which would have lost a qubit).
-    inner_m = (m + 1) // 2
-    inner_n = (n + 1) // 2
-    block_log_m = m // 2
-    block_log_n = n // 2
+    #
+    # The optional `inner_m` / `inner_n` overrides pin the inner basis (and
+    # therefore the block-pixel-size, since block_size = 2**inner_*) to a
+    # fixed scale regardless of m. Used by the *_8 variants below to force
+    # 8×8 blocks (inner_m=3) at any m≥3, matching block_dct_8 / block_fft_8.
+    if inner_m is None:
+        inner_m = (m + 1) // 2
+    if inner_n is None:
+        inner_n = (n + 1) // 2
+    block_log_m = m - inner_m
+    block_log_n = n - inner_n
+    if block_log_m < 0 or block_log_n < 0:
+        raise ValueError(
+            f"_blocked: inner_m={inner_m}, inner_n={inner_n} larger than "
+            f"outer m={m}, n={n}; block_log would be negative"
+        )
     inner = inner_cls(m=inner_m, n=inner_n) if seed == 0 else inner_cls(m=inner_m, n=inner_n)
     return pdft.BlockedBasis(inner=inner, block_log_m=block_log_m, block_log_n=block_log_n)
 
@@ -45,10 +58,18 @@ BASIS_FACTORIES: dict[str, BasisFactory] = {
     "entangled_qft": lambda m, n, seed=0: pdft.EntangledQFTBasis(m=m, n=n, seed=seed),
     "tebd":          lambda m, n, seed=0: pdft.TEBDBasis(m=m, n=n, seed=seed),
     "mera":          lambda m, n, seed=0: pdft.MERABasis(m=m, n=n, seed=seed),
-    # Block topologies (3): compared against blockDCT.
+    # Block topologies (3): default split — inner basis at (m+1)//2.
+    # At QuickDraw m=5: inner_m=3 → 8×8 blocks. At DIV2K m=8: inner_m=4 → 16×16 blocks.
     "blocked":       lambda m, n, seed=0: _blocked(m, n, seed, pdft.QFTBasis),
     "rich":          lambda m, n, seed=0: _blocked(m, n, seed, pdft.RichBasis),
     "real_rich":     lambda m, n, seed=0: _blocked(m, n, seed, pdft.RealRichBasis),
+    # Block topologies, fixed 8×8 block size (inner_m=inner_n=3) at any m≥3.
+    # Apples-to-apples with classical block_dct_8 / block_fft_8 (which also
+    # operate on 8×8 patches regardless of image size). At DIV2K m=8: inner
+    # basis at m=3 (3 qubits/axis) replicated across a 32×32 grid of 8×8 blocks.
+    "blocked_8":     lambda m, n, seed=0: _blocked(m, n, seed, pdft.QFTBasis,       inner_m=3, inner_n=3),
+    "rich_8":        lambda m, n, seed=0: _blocked(m, n, seed, pdft.RichBasis,      inner_m=3, inner_n=3),
+    "real_rich_8":   lambda m, n, seed=0: _blocked(m, n, seed, pdft.RealRichBasis,  inner_m=3, inner_n=3),
 }
 
 __all__ = ["BASIS_FACTORIES", "BasisFactory"]


### PR DESCRIPTION
## Summary

Adds three new \`BASIS_FACTORIES\` entries — \`blocked_8\`, \`rich_8\`, \`real_rich_8\` — that produce 8×8 blocks at any m≥3, matching the classical \`block_dct_8\` / \`block_fft_8\` baselines. Required by the DIV2K-8q PCA-vs-block-DCT experiment (in flight on \`feat/div2k-8q-pca-vs-block-dct\`).

## Why

The default \`blocked\` / \`rich\` / \`real_rich\` factories use a "split-half" partition (\`inner_m = (m+1)//2\`) which yields 8×8 blocks at QuickDraw m=5 (apples-to-apples vs block_dct_8) but **16×16 blocks at DIV2K m=8** (apples-to-pears). The user wants the DIV2K experiment to compare 8×8 trained block bases vs 8×8 classical block-DCT directly. The new \`*_8\` variants pin the inner basis to 3 qubits/axis regardless of m.

## Mechanical change

\`_blocked()\` gains optional \`inner_m\` / \`inner_n\` parameters. When supplied, they pin the inner basis (and therefore the block-pixel-size, since block_size = 2**inner_m) to a fixed scale. The new factories pass \`inner_m=inner_n=3\` explicitly. \`block_log_m\` is computed as \`m - inner_m\` so the tiling always covers the image; a guard raises if that goes negative (\`m < inner_m\`).

## Verification

\`\`\`bash
$ /opt/conda/envs/pdft/bin/python -c "from pdft_benchmarks.bases import BASIS_FACTORIES; ..."
Factories: ['blocked', 'blocked_8', 'entangled_qft', 'mera', 'qft', 'real_rich', 'real_rich_8', 'rich', 'rich_8', 'tebd']
blocked_8@m=n=8:  block_log_m=5, inner=(m=3, n=3)   # 32×32 grid of 8×8 blocks ✓
rich_8@m=n=8:     block_log_m=5, inner=(m=3, n=3)
real_rich_8@m=n=8:block_log_m=5, inner=(m=3, n=3)
blocked@m=n=8 (default unchanged): block_log_m=4, inner_m=4   # 16×16 grid of 16×16 blocks
blocked@m=n=5 (QuickDraw, unchanged): block_log_m=2, inner_m=3 # 4×4 grid of 8×8 blocks ✓
\`\`\`

Existing \`blocked\` / \`rich\` / \`real_rich\` behavior is unchanged at every m (no risk to QuickDraw or any other consumer). The \`*_8\` variants are purely additive.

## Test plan

- [ ] \`pytest tests/ --no-cov\` doesn't regress.
- [ ] At DIV2K m=8, \`BASIS_FACTORIES['blocked_8'](8, 8, 0).block_log_m == 5\` and \`.inner.m == 3\`.
- [ ] At any m, \`BASIS_FACTORIES['blocked'](m, m, 0)\` produces a basis with the same shape as before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)