### PR TITLE
feat(baselines): block-size sweep registry entries

### DIFF
--- a/src/pdft_benchmarks/baselines.py
+++ b/src/pdft_benchmarks/baselines.py
@@ -196,6 +196,10 @@ def _block_pca_b_builder(block: int):
 
 
 def _block_pca_b_rank_builder(block: int):
+    """Builder factory for block-PCA with rank-rule truncation. Kept
+    parametrised by `block` for symmetry with `_block_pca_b_builder` and
+    `_block_bd_pca_b_builder`; the rank-rule sweep itself is out of scope
+    (spec §5.1) — only the b=8 back-compat alias is registered."""
     def builder(train_imgs):
         basis = fit_block_pca(train_imgs, block=block)
         def fn(image, keep_ratio):
@@ -206,6 +210,10 @@ def _block_pca_b_rank_builder(block: int):
 
 
 def _block_bd_pca_b_builder(block: int):
+    """Builder factory for block-mode bilateral 2D-PCA: separable column +
+    row eigenbases fit per b×b patch (pooled across all training patches).
+    The separable constraint regularises the b²×b² unconstrained KLT —
+    fewer parameters (2b² vs b⁴), better generalisation on test data."""
     def builder(train_imgs):
         basis = fit_block_bd_pca(train_imgs, block=block)
         def fn(image, keep_ratio):

--- a/src/pdft_benchmarks/baselines.py
+++ b/src/pdft_benchmarks/baselines.py
@@ -184,26 +184,47 @@ from .pca import (
 )
 
 
-def _block_pca_8_builder(train_imgs):
-    basis = fit_block_pca(train_imgs, block=8)
-    def fn(image, keep_ratio):
-        return pca_recover(basis, pca_compress(basis, image, keep_ratio))
-    fn._pca_basis = basis
-    return fn
+def _block_pca_b_builder(block: int):
+    """Return a builder(train_imgs) -> compress_fn for block-PCA at the given block size."""
+    def builder(train_imgs):
+        basis = fit_block_pca(train_imgs, block=block)
+        def fn(image, keep_ratio):
+            return pca_recover(basis, pca_compress(basis, image, keep_ratio))
+        fn._pca_basis = basis
+        return fn
+    return builder
+
+
+def _block_pca_b_rank_builder(block: int):
+    def builder(train_imgs):
+        basis = fit_block_pca(train_imgs, block=block)
+        def fn(image, keep_ratio):
+            return pca_recover(basis, pca_compress_rank(basis, image, keep_ratio))
+        fn._pca_basis = basis
+        return fn
+    return builder
+
+
+def _block_bd_pca_b_builder(block: int):
+    def builder(train_imgs):
+        basis = fit_block_bd_pca(train_imgs, block=block)
+        def fn(image, keep_ratio):
+            return bd_pca_recover(basis, bd_pca_compress(basis, image, keep_ratio))
+        fn._bd_pca_basis = basis
+        return fn
+    return builder
+
+
+# Back-compat aliases — preserve the names already referenced in the registry.
+_block_pca_8_builder       = _block_pca_b_builder(8)
+_block_pca_8_rank_builder  = _block_pca_b_rank_builder(8)
+_block_bd_pca_8_builder    = _block_bd_pca_b_builder(8)
 
 
 def _global_pca_builder(train_imgs):
     basis = fit_global_pca(train_imgs)
     def fn(image, keep_ratio):
         return pca_recover(basis, pca_compress(basis, image, keep_ratio))
-    fn._pca_basis = basis
-    return fn
-
-
-def _block_pca_8_rank_builder(train_imgs):
-    basis = fit_block_pca(train_imgs, block=8)
-    def fn(image, keep_ratio):
-        return pca_recover(basis, pca_compress_rank(basis, image, keep_ratio))
     fn._pca_basis = basis
     return fn
 
@@ -218,14 +239,6 @@ def _global_pca_rank_builder(train_imgs):
 
 def _bd_pca_builder(train_imgs):
     basis = fit_bd_pca(train_imgs)
-    def fn(image, keep_ratio):
-        return bd_pca_recover(basis, bd_pca_compress(basis, image, keep_ratio))
-    fn._bd_pca_basis = basis
-    return fn
-
-
-def _block_bd_pca_8_builder(train_imgs):
-    basis = fit_block_bd_pca(train_imgs, block=8)
     def fn(image, keep_ratio):
         return bd_pca_recover(basis, bd_pca_compress(basis, image, keep_ratio))
     fn._bd_pca_basis = basis

--- a/src/pdft_benchmarks/baselines.py
+++ b/src/pdft_benchmarks/baselines.py
@@ -254,22 +254,27 @@ def _bd_pca_builder(train_imgs):
 BASELINE_FACTORIES = {
     "fft":              lambda train_imgs: global_fft_compress,
     "dct":              lambda train_imgs: global_dct_compress,
-    "block_fft_8":      lambda train_imgs: lambda img, keep_ratio: block_fft_compress(img, keep_ratio, block=8),
-    "block_dct_8":      lambda train_imgs: lambda img, keep_ratio: block_dct_compress(img, keep_ratio, block=8),
     "pca":              _global_pca_builder,
-    "block_pca_8":      _block_pca_8_builder,
     # Bilateral 2D-PCA: separable column+row eigenbases on H×W matrix-form
     # images. Sidesteps the d/N rank-deficiency of flat PCA by fitting
     # H×H column-covariance and W×W row-covariance, both full-rank when
     # N·W (or N·H) >= H (or W).
     "bd_pca":           _bd_pca_builder,
-    # Block-mode bilateral 2D-PCA: separable column+row eigenbases fit per
-    # b×b patch (pooled across all training patches). The separable
-    # constraint regularizes the b²×b² unconstrained KLT — fewer
-    # parameters (2b² vs b⁴), better generalization on test data.
-    "block_bd_pca_8":   _block_bd_pca_8_builder,
-    # Rank-truncation variants (textbook KLT-optimal rule for PCA;
-    # zigzag scan order for DCT — fair comparator to eigenvalue-rank PCA).
+
+    # Block transforms, parametrised by block size b ∈ {2, 4, 8, 16, 32, 64, 128}.
+    # b=8 is the headline; b≠8 is the sweep extension (spec §4).
+    # Image-side global transforms cover b=N (32 for QuickDraw, 256 for DIV2K).
+    **{f"block_fft_{b}":     (lambda b=b: lambda train_imgs:
+                               (lambda img, keep_ratio: block_fft_compress(img, keep_ratio, block=b)))()
+       for b in (2, 4, 8, 16, 32, 64, 128)},
+    **{f"block_dct_{b}":     (lambda b=b: lambda train_imgs:
+                               (lambda img, keep_ratio: block_dct_compress(img, keep_ratio, block=b)))()
+       for b in (2, 4, 8, 16, 32, 64, 128)},
+    **{f"block_pca_{b}":     _block_pca_b_builder(b)     for b in (2, 4, 8, 16, 32, 64, 128)},
+    **{f"block_bd_pca_{b}":  _block_bd_pca_b_builder(b)  for b in (2, 4, 8, 16, 32, 64, 128)},
+
+    # Rank-truncation appendix variants (kept at b=8 only — they are not
+    # part of the headline sweep; see spec §5.1).
     "dct_rank":         lambda train_imgs: global_dct_compress_zigzag,
     "block_dct_8_rank": lambda train_imgs: lambda img, keep_ratio: block_dct_compress_zigzag(img, keep_ratio, block=8),
     "pca_rank":         _global_pca_rank_builder,

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -226,3 +226,30 @@ def test_global_pca_builder_returns_working_callable():
     assert out.shape == test.shape
     assert hasattr(fn, "_pca_basis")
     assert fn._pca_basis.block is None
+
+
+import pytest  # noqa: E402
+
+
+@pytest.mark.parametrize("block", [4, 8, 16])
+def test_block_pca_builder_factory_parametrised(img_256, block):
+    """_block_pca_b_builder(block) should return a working builder for any b dividing N."""
+    from pdft_benchmarks.baselines import _block_pca_b_builder
+    rng = np.random.default_rng(2)
+    train_imgs = rng.uniform(0.0, 1.0, size=(20, 256, 256))
+    builder = _block_pca_b_builder(block)
+    fn = builder(train_imgs)
+    out = fn(img_256, keep_ratio=0.5)
+    assert out.shape == img_256.shape
+    assert out.dtype == np.float64
+
+
+@pytest.mark.parametrize("block", [4, 8, 16])
+def test_block_bd_pca_builder_factory_parametrised(img_256, block):
+    from pdft_benchmarks.baselines import _block_bd_pca_b_builder
+    rng = np.random.default_rng(3)
+    train_imgs = rng.uniform(0.0, 1.0, size=(20, 256, 256))
+    builder = _block_bd_pca_b_builder(block)
+    fn = builder(train_imgs)
+    out = fn(img_256, keep_ratio=0.5)
+    assert out.shape == img_256.shape

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -124,18 +124,22 @@ def test_dct_module_imports():
 from pdft_benchmarks.baselines import BASELINE_FACTORIES  # noqa: E402
 
 
-def test_baseline_factories_are_builders(img_32):
-    """Every BASELINE_FACTORIES entry is callable(train_imgs) -> callable(image, kr) -> ndarray."""
+def test_baseline_factories_are_builders(img_256):
+    """Every BASELINE_FACTORIES entry is callable(train_imgs) -> callable(image, kr) -> ndarray.
+
+    Uses a 256×256 image so that all sweep block sizes (2,4,8,16,32,64,128) divide
+    the image dimension evenly.
+    """
     rng = np.random.default_rng(42)
     # Distinct images so PCA's covariance is non-degenerate.
-    train_imgs = rng.uniform(0.0, 1.0, size=(8, 32, 32)).astype(np.float64)
+    train_imgs = rng.uniform(0.0, 1.0, size=(8, 256, 256)).astype(np.float64)
     for name, builder in BASELINE_FACTORIES.items():
         assert callable(builder), f"{name} is not callable"
         fn = builder(train_imgs)
         assert callable(fn), f"{name}(train_imgs) did not return a callable"
-        recovered = fn(img_32, 0.5)
-        assert recovered.shape == img_32.shape, (
-            f"{name} recovered shape {recovered.shape} != {img_32.shape}"
+        recovered = fn(img_256, 0.5)
+        assert recovered.shape == img_256.shape, (
+            f"{name} recovered shape {recovered.shape} != {img_256.shape}"
         )
 
 

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -232,9 +232,6 @@ def test_global_pca_builder_returns_working_callable():
     assert fn._pca_basis.block is None
 
 
-import pytest  # noqa: E402
-
-
 @pytest.mark.parametrize("block", [4, 8, 16])
 def test_block_pca_builder_factory_parametrised(img_256, block):
     """_block_pca_b_builder(block) should return a working builder for any b dividing N."""
@@ -250,6 +247,7 @@ def test_block_pca_builder_factory_parametrised(img_256, block):
 
 @pytest.mark.parametrize("block", [4, 8, 16])
 def test_block_bd_pca_builder_factory_parametrised(img_256, block):
+    """_block_bd_pca_b_builder(block) should return a working builder for any b dividing N."""
     from pdft_benchmarks.baselines import _block_bd_pca_b_builder
     rng = np.random.default_rng(3)
     train_imgs = rng.uniform(0.0, 1.0, size=(20, 256, 256))
@@ -257,3 +255,4 @@ def test_block_bd_pca_builder_factory_parametrised(img_256, block):
     fn = builder(train_imgs)
     out = fn(img_256, keep_ratio=0.5)
     assert out.shape == img_256.shape
+    assert out.dtype == np.float64

--- a/tests/test_block_size_sweep_factories.py
+++ b/tests/test_block_size_sweep_factories.py
@@ -1,0 +1,39 @@
+"""Layer A: registry sanity for the b-sweep additions. No GPU, no training."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pdft_benchmarks.baselines import BASELINE_FACTORIES
+
+
+CLASSICAL_B_QUICKDRAW = (2, 4, 8, 16)        # 32 = global, covered by 'dct' / 'fft'
+CLASSICAL_B_DIV2K     = (4, 8, 16, 32, 64, 128)  # 256 = global, covered by 'dct' / 'fft'
+
+
+@pytest.mark.parametrize("b", sorted(set(CLASSICAL_B_QUICKDRAW) | set(CLASSICAL_B_DIV2K)))
+@pytest.mark.parametrize("kind", ["block_dct", "block_fft"])
+def test_classical_block_b_factory_exists(kind, b):
+    key = f"{kind}_{b}"
+    assert key in BASELINE_FACTORIES, f"missing factory key: {key}"
+
+
+@pytest.mark.parametrize("b", sorted(set(CLASSICAL_B_QUICKDRAW) | set(CLASSICAL_B_DIV2K)))
+@pytest.mark.parametrize("kind", ["block_pca", "block_bd_pca"])
+def test_pca_block_b_factory_exists(kind, b):
+    key = f"{kind}_{b}"
+    assert key in BASELINE_FACTORIES, f"missing factory key: {key}"
+
+
+@pytest.mark.parametrize("b", [4, 16])
+def test_block_dct_b_runs(b):
+    """The new block_dct_b / block_fft_b factories should produce working compress fns."""
+    rng = np.random.default_rng(5)
+    img = rng.uniform(0.0, 1.0, size=(64, 64))
+    fn_dct = BASELINE_FACTORIES[f"block_dct_{b}"](train_imgs=None)
+    fn_fft = BASELINE_FACTORIES[f"block_fft_{b}"](train_imgs=None)
+    out_dct = fn_dct(img, keep_ratio=0.3)
+    out_fft = fn_fft(img, keep_ratio=0.3)
+    assert out_dct.shape == img.shape
+    assert out_fft.shape == img.shape


### PR DESCRIPTION
## Summary

- Generalize `_block_pca_b_builder` / `_block_bd_pca_b_builder` factories to take a `block` parameter; preserve `_8` aliases for back-compat.
- Add `block_fft_b`, `block_dct_b`, `block_pca_b`, `block_bd_pca_b` registry entries for b ∈ {2, 4, 8, 16, 32, 64, 128} — covers the classical sweep grid for both datasets (QuickDraw b ≤ 16, DIV2K b ≤ 128).
- Tests in `tests/test_block_size_sweep_factories.py` for registry presence and runtime correctness.

Preparatory step toward the appendix block-size sweep (spec `2026-05-08-block-size-sweep-and-adaptive-design.md`, Claim 2). No training, no GPU. Existing 8×8 headline registry keys are untouched.

## Test plan

- [x] `pytest tests/test_baselines.py` passes.
- [x] `pytest tests/test_block_size_sweep_factories.py` passes.
- [x] Existing `block_dct_8` / `block_pca_8` / `block_bd_pca_8` consumers in `experiments/div2k_8q_pca_vs_block_dct.py` and `experiments/quickdraw_pca_vs_block_dct.py` still find their factory keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)