### PR TITLE
render_freq_recon_grid: --methods flag for compact subsets

### DIFF
--- a/tools/render_freq_recon_grid.py
+++ b/tools/render_freq_recon_grid.py
@@ -69,6 +69,12 @@ def main():
     ap.add_argument("--dataset", choices=["quickdraw", "div2k_8q"],
                     default="quickdraw",
                     help="Which dataset+experiment-tree to render against.")
+    ap.add_argument("--methods", type=str, default="",
+                    help="Comma-separated method names to include "
+                         "(e.g. 'fft,dct,qft,block_dct_8,real_rich_8'). "
+                         "Empty → include all available. The block-wrapped-"
+                         "before-global ordering is preserved within the "
+                         "selected subset.")
     args = ap.parse_args()
 
     DATASET_CONFIG = {
@@ -211,6 +217,18 @@ def main():
     sample_key = (image_labels[0], keep_ratios[0])
     block_methods  = [m for m in block_methods_pref  if m in rec[sample_key]]
     global_methods = [m for m in global_methods_pref if m in rec[sample_key]]
+    if args.methods:
+        requested = [m.strip() for m in args.methods.split(",") if m.strip()]
+        available = set(block_methods) | set(global_methods)
+        missing = [m for m in requested if m not in available]
+        if missing:
+            raise ValueError(
+                f"requested methods not available: {missing}; "
+                f"available: {sorted(available)}"
+            )
+        requested_set = set(requested)
+        block_methods  = [m for m in block_methods  if m in requested_set]
+        global_methods = [m for m in global_methods if m in requested_set]
     methods = block_methods + global_methods
     n_methods = len(methods)
     n_cols = 1 + n_methods


### PR DESCRIPTION
## Summary

Adds `--methods` to `tools/render_freq_recon_grid.py`, a comma-separated list of method names that filters the rendered gallery to a representative subset while preserving the existing block-wrapped-before-global column ordering.

The default behavior (no flag) is unchanged — all available methods are still rendered, so existing call sites (and the 13-method figures already checked into `results/*/figures/`) are unaffected.

Use case: the paper wants a 5-method headline figure (`fft,dct,qft,block_dct_8,real_rich_8`) for the main text and the existing 13-method gallery for the appendix. Same renderer, two output PDFs.

Validation rejects names that aren't present in `rec[]` (typos, missing trained checkpoints) with a sorted "available" list to make the fix obvious.

## Test plan

- [x] Default behavior unchanged: no `--methods` → full 13-method gallery (same as before).
- [x] `--methods fft,dct,block_dct_8` on QuickDraw img0 produces a 4-column reconstruction grid (original + 3) and a 4-column freq grid; `block_dct_8` appears first (block-wrapped), `fft`/`dct` to its right (global); PSNR labels and color-coded headers preserved.
- [ ] `--methods fft,dct,qft,block_dct_8,real_rich_8` on DIV2K-8q img390 (requires `trained_*.json` for `qft` and `real_rich_8`; deferred to the benchmark machine).
- [ ] `--methods bogus_name` produces a clean error listing available methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)