### PR TITLE
fix(freq-plots): remove erroneous 90° rotation in spectrum renderers

### DIFF
--- a/src/pdft_benchmarks/analysis.py
+++ b/src/pdft_benchmarks/analysis.py
@@ -196,8 +196,10 @@ def _draw_frequency_spectra(
     """2D frequency spectra: peak-normalised log|F| per method, shared colorbar.
 
     Mirror of `analyze_frequency_space.jl` (A) panel: one column per method,
-    same colormap and colorrange across all methods. Rotation 90° matches
-    Julia's `rotr90` orientation convention.
+    same colormap and colorrange across all methods. matplotlib's imshow
+    has origin top-left (y-axis down), so the natural array orientation
+    already aligns horizontal/vertical spatial axes with k_x/k_y — no
+    rotation is needed (unlike Julia's heatmap which is y-up by default).
     """
     methods = list(method_magnitudes.keys())
     logmags, zmin, zmax = _peak_normalized_log(method_magnitudes)
@@ -215,8 +217,7 @@ def _draw_frequency_spectra(
 
     im = None
     for ax, name in zip(flat[1:], methods):
-        lm = np.rot90(logmags[name], k=1)  # match Julia's rotr90
-        im = ax.imshow(lm, cmap="inferno", vmin=zmin, vmax=zmax)
+        im = ax.imshow(logmags[name], cmap="inferno", vmin=zmin, vmax=zmax)
         ax.set_title(name, fontsize=9)
         ax.set_xticks([])
         ax.set_yticks([])

--- a/tools/render_freq_recon_grid.py
+++ b/tools/render_freq_recon_grid.py
@@ -310,9 +310,8 @@ def main():
         axes_f[0].set_xticks([]); axes_f[0].set_yticks([])
         last_im = None
         for c_idx, name in enumerate(methods, start=1):
-            spec = np.rot90(log_freq[name])
             last_im = axes_f[c_idx].imshow(
-                spec, cmap="viridis", vmin=zmin, vmax=zmax,
+                log_freq[name], cmap="viridis", vmin=zmin, vmax=zmax,
                 interpolation="nearest", aspect="equal",
             )
             axes_f[c_idx].set_xticks([]); axes_f[c_idx].set_yticks([])


### PR DESCRIPTION
## Summary

The freq-spectrum imshow calls in `tools/render_freq_recon_grid.py` and `src/pdft_benchmarks/analysis.py::_draw_frequency_spectra` wrapped each panel in `np.rot90(..., k=1)`, with a comment claiming this matched Julia's \`rotr90\` orientation convention. Two problems compounded:

1. **Direction mismatch.** Julia's \`rotr90\` is **clockwise**, but \`np.rot90(arr, k=1)\` is **counter-clockwise** (= Julia's \`rotl90\`). The rotation went the wrong way even on the comment's own terms.
2. **The rotation shouldn't be there at all in matplotlib.** matplotlib's \`imshow\` origin is top-left (y-axis down), so an array \`F[k_y, k_x]\` from \`np.fft.fft2\` already aligns horizontal/vertical spatial axes with \`k_x\`/\`k_y\`. No fixup needed. Julia's \`rotr90\` was likely compensating for Julia's heatmap default (y-axis up).

Effect: every freq spectrum was displayed rotated 90° relative to its spatial reconstruction, across both QuickDraw and DIV2K-8q outputs.

## Numerical verification

64×64 horizontal-stripe test image (f(x,y) = δ(y - y0)). Theory: F = δ(k_x), giving a vertical streak at k_x=0 in the spectrum.

| | Energy along k_x=0 col | Energy along k_y=0 row |
|---|---|---|
| Spatial fact | (vertical streak expected) | (≈zero expected) |
| Numerical | 6.35×10³ | 2.56×10² |

Ratio 25×: confirms theory. Without \`rot90\` the spectrum is rendered as a vertical streak; with \`rot90(k=1)\` it becomes horizontal — i.e. rotated 90° CCW from truth.

## Test plan

- [x] Removed the rotation from both call sites (\`tools/render_freq_recon_grid.py\` and \`src/pdft_benchmarks/analysis.py:218\`); updated docstring on \`_draw_frequency_spectra\` to explain why no rotation is needed.
- [x] Re-rendered DIV2K img11 freq grid with the fix; FFT panel now shows the expected vertical streak (image has dominant horizontal building features), where the previous rendering had a rotated horizontal streak.
- [ ] After merge: re-render all \`*_freq.{pdf,svg}\` panels in \`results/{quickdraw,div2k_8q}_pca_vs_block_dct/figures/\` — they were saved with the rotation applied and need refreshing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)