### PR TITLE
chore: factor shared driver boilerplate into experiment_utils

### DIFF
--- a/experiments/div2k_8q_l1_init_anchor.py
+++ b/experiments/div2k_8q_l1_init_anchor.py
@@ -75,7 +75,6 @@ def main() -> int:
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
 
     # Imports below trigger JAX device discovery; must come AFTER env var.
-    import numpy as np
     import jax
     import pdft
     import pdft.io  # noqa: F401
@@ -83,6 +82,7 @@ def main() -> int:
     from pdft_benchmarks.identity_reg import L1InitAnchorMSELoss
     from pdft_benchmarks.datasets.div2k import load_div2k
     from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.experiment_utils import serialize_tensors
     from pdft_benchmarks.presets import get_preset
 
     bases = [b.strip() for b in args.bases.split(",") if b.strip()]
@@ -192,11 +192,7 @@ def main() -> int:
                 "basis": basis_name,
                 "lam": lam,
                 "m": m, "n": n,
-                "tensors": [
-                    {"real": np.asarray(t).real.tolist(),
-                     "imag": np.asarray(t).imag.tolist()}
-                    for t in result.basis.tensors
-                ],
+                "tensors": serialize_tensors(result.basis.tensors),
             }, indent=2))
             psnr20 = eval_metrics["0.2"]["mean_psnr"]
             print(f"[l1_anchor]   PSNR @ rho=0.20: {psnr20:.2f} dB")

--- a/experiments/div2k_8q_pca_vs_block_dct.py
+++ b/experiments/div2k_8q_pca_vs_block_dct.py
@@ -90,22 +90,16 @@ def main() -> int:
         return 2
 
     # Imports below trigger JAX device discovery; must come AFTER the env var.
-    from dataclasses import replace
+    # (experiment_utils is JAX-free, but kept here alongside the pipeline import
+    # for locality.)
+    from pdft_benchmarks.experiment_utils import apply_preset_overrides
     from pdft_benchmarks.pipeline import run_experiment
-    from pdft_benchmarks.presets import get_preset
 
-    preset = args.preset
-    if args.no_early_stop or args.epochs is not None:
-        # Resolve the preset early so we can apply overrides.
-        base = get_preset("div2k_8q", preset) if isinstance(preset, str) else preset
-        kwargs = {}
-        if args.no_early_stop:
-            kwargs["early_stopping_patience"] = 10**9
-        if args.epochs is not None:
-            kwargs["epochs"] = args.epochs
-        preset = replace(base, **kwargs)
-        print(f"[div2k-8q] preset overrides: epochs={preset.epochs}, "
-              f"patience={preset.early_stopping_patience}")
+    # Preset-registry key is "div2k_8q"; the dataset-loader key below is "div2k".
+    preset = apply_preset_overrides(
+        args.preset, dataset="div2k_8q", tag="div2k-8q",
+        no_early_stop=args.no_early_stop, epochs=args.epochs,
+    )
 
     res = run_experiment(
         dataset="div2k",

--- a/experiments/div2k_block_size_sweep.py
+++ b/experiments/div2k_block_size_sweep.py
@@ -64,24 +64,16 @@ def main() -> int:
         print(f"[div2k-sweep] unknown bases: {unknown}; valid: {ALL_BASES}", file=sys.stderr)
         return 2
 
-    from dataclasses import replace
+    from pdft_benchmarks.experiment_utils import apply_preset_overrides
     from pdft_benchmarks.pipeline import run_experiment
-    from pdft_benchmarks.presets import get_preset
 
-    preset = args.preset
-    if args.no_early_stop or args.epochs is not None:
-        # Note: the preset registry key is "div2k_8q" (the experiment) but the
-        # data-loader key passed to run_experiment below is "div2k" (the dataset).
-        # The asymmetry is intentional and matches div2k_8q_pca_vs_block_dct.py.
-        base = get_preset("div2k_8q", preset)
-        kwargs = {}
-        if args.no_early_stop:
-            kwargs["early_stopping_patience"] = 10**9
-        if args.epochs is not None:
-            kwargs["epochs"] = args.epochs
-        preset = replace(base, **kwargs)
-        print(f"[div2k-sweep] preset overrides: epochs={preset.epochs}, "
-              f"patience={preset.early_stopping_patience}")
+    # Note: the preset registry key is "div2k_8q" (the experiment) but the
+    # data-loader key passed to run_experiment below is "div2k" (the dataset).
+    # The asymmetry is intentional and matches div2k_8q_pca_vs_block_dct.py.
+    preset = apply_preset_overrides(
+        args.preset, dataset="div2k_8q", tag="div2k-sweep",
+        no_early_stop=args.no_early_stop, epochs=args.epochs,
+    )
 
     res = run_experiment(
         dataset="div2k",

--- a/experiments/qft_freeze_sweep.py
+++ b/experiments/qft_freeze_sweep.py
@@ -27,20 +27,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import subprocess
 import sys
 import time
 from dataclasses import replace
 from pathlib import Path
-
-
-def _git_sha() -> str:
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], text=True
-        ).strip()
-    except Exception:
-        return "unknown"
 
 
 def main() -> int:
@@ -66,7 +56,6 @@ def main() -> int:
     if args.gpu is not None:
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
 
-    import numpy as np
     import jax
     import pdft
     import pdft.io  # noqa: F401
@@ -76,6 +65,7 @@ def main() -> int:
     )
     from pdft_benchmarks.datasets import load_div2k
     from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.experiment_utils import git_sha, serialize_tensors
     from pdft_benchmarks.presets import get_preset
 
     # GPU fail-fast — same pattern as qft_progressive driver.
@@ -228,9 +218,7 @@ def main() -> int:
             "m": m, "n": n,
             "inner_m": int(args.inner_m), "inner_n": int(args.inner_n),
             "frozen_indices": list(spec["frozen_indices"]),
-            "tensors": [{"real": np.asarray(t).real.tolist(),
-                         "imag": np.asarray(t).imag.tolist()}
-                        for t in result.basis.tensors],
+            "tensors": serialize_tensors(result.basis.tensors),
         }, indent=2))
         (out_dir / "env.json").write_text(json.dumps({
             "experiment": "qft_freeze_sweep",
@@ -244,7 +232,7 @@ def main() -> int:
             "preset_name": args.preset,
             "preset_epochs": int(args.epochs),
             "device": str(jax.devices()[0]),
-            "git_sha": _git_sha(),
+            "git_sha": git_sha(short=False),
         }, indent=2))
 
         summaries.append({
@@ -265,7 +253,7 @@ def main() -> int:
         "inner_m": int(args.inner_m), "inner_n": int(args.inner_n),
         "cells": summaries,
         "anchors": {"qft": 31.29, "qft_identity": 31.66, "blocked_8": 32.26},
-        "git_sha": _git_sha(),
+        "git_sha": git_sha(short=False),
     }, indent=2))
 
     print(f"\n[qft_freeze_sweep] complete. Manifest: {manifest_path}")

--- a/experiments/qft_identity_regularization.py
+++ b/experiments/qft_identity_regularization.py
@@ -70,7 +70,6 @@ def main() -> int:
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
 
     # Imports below trigger JAX device discovery; must come AFTER env var.
-    import numpy as np
     import jax
     import pdft
     import pdft.io  # noqa: F401 — register pdft.io submodule for evaluate_basis_shared
@@ -83,6 +82,7 @@ def main() -> int:
     from pdft_benchmarks.datasets.quickdraw import load_quickdraw
     from pdft_benchmarks.datasets.tuberlin import load_tuberlin
     from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.experiment_utils import serialize_tensors
     from pdft_benchmarks.presets import get_preset
 
     lambdas = [float(x.strip()) for x in args.lambdas.split(",") if x.strip()]
@@ -198,9 +198,7 @@ def main() -> int:
             "lam": lam, "outer_weight": W,
             "inner_m": args.inner_m, "inner_n": args.inner_n,
             "m": m, "n": n,
-            "tensors": [{"real": np.asarray(t).real.tolist(),
-                         "imag": np.asarray(t).imag.tolist()}
-                        for t in result.basis.tensors],
+            "tensors": serialize_tensors(result.basis.tensors),
         }, indent=2))
         psnr20 = eval_metrics["0.2"]["mean_psnr"]
         print(f"[qft_id_reg]   PSNR @ rho=0.20: {psnr20:.2f} dB")

--- a/experiments/qft_progressive.py
+++ b/experiments/qft_progressive.py
@@ -44,7 +44,6 @@ import argparse
 import hashlib
 import json
 import os
-import subprocess
 import sys
 import time
 from dataclasses import replace
@@ -72,15 +71,6 @@ ANCHORS = {
     "tuberlin_8q": {},
     "quickdraw_5q": {},
 }
-
-
-def _git_sha() -> str:
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], text=True
-        ).strip()
-    except Exception:
-        return "unknown"
 
 
 def _sha256_file(path: Path) -> str:
@@ -167,13 +157,13 @@ def main() -> int:
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
 
     # IMPORTANT: imports after env var so JAX picks up the device.
-    import numpy as np
     import jax
     import pdft
     import pdft.io  # noqa: F401 — needed by evaluate_basis_shared
     from pdft_benchmarks.bases import family_identity_basis, family_random_basis
     from pdft_benchmarks.datasets import load_div2k, load_quickdraw, load_tuberlin
     from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.experiment_utils import git_sha, serialize_tensors
     from pdft_benchmarks.presets import get_preset
 
     family = args.family
@@ -351,9 +341,7 @@ def main() -> int:
                 "stage_k": k,
                 "m": int(inner_trained.m),
                 "n": int(inner_trained.n),
-                "tensors": [{"real": np.asarray(t).real.tolist(),
-                             "imag": np.asarray(t).imag.tolist()}
-                            for t in inner_trained.tensors],
+                "tensors": serialize_tensors(inner_trained.tensors),
             }, indent=2))
 
             metrics_path.write_text(json.dumps({
@@ -393,7 +381,7 @@ def main() -> int:
                 "preset_name": args.preset,
                 "preset_epochs_per_stage": int(args.epochs_per_stage),
                 "device": str(jax.devices()[0]),
-                "git_sha": _git_sha(),
+                "git_sha": git_sha(short=False),
             }, indent=2))
 
         # COMMON path (both resume and train): record manifest summary. No
@@ -422,7 +410,7 @@ def main() -> int:
         "total_epochs": int(args.epochs_per_stage * n_stages),
         "stages": stage_summaries,
         "anchors": ANCHORS.get(args.dataset, {}).get(family, {}),
-        "git_sha": _git_sha(),
+        "git_sha": git_sha(short=False),
     }, indent=2))
 
     print(f"\n[{exp}] sweep complete. Manifest: {manifest_path}")

--- a/experiments/qft_unfreeze.py
+++ b/experiments/qft_unfreeze.py
@@ -15,17 +15,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import subprocess
 import sys
 import time
 from pathlib import Path
-
-
-def _git_sha() -> str:
-    try:
-        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-    except Exception:
-        return "unknown"
 
 
 def main() -> int:
@@ -73,6 +65,7 @@ def main() -> int:
     from pdft_benchmarks.bases import family_random_basis, qft_identity_basis
     from pdft_benchmarks.datasets import load_div2k, load_quickdraw, load_tuberlin
     from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.experiment_utils import git_sha, serialize_tensors
     from pdft_benchmarks.presets import get_preset
     from pdft_benchmarks.unfreeze import qft_unfreeze_orders, train_progressive_unfreeze
 
@@ -154,12 +147,11 @@ def main() -> int:
             "batch": len(fixed_batch), "k_train": k_train,
             "steps": res.trace,
             "stages": [vars(s) for s in res.stages],
-            "git_sha": _git_sha(),
+            "git_sha": git_sha(short=False),
         }, indent=2))
         (cell / "trained_final.json").write_text(json.dumps({
             "ordering": name, "m": int(res.basis.m), "n": int(res.basis.n),
-            "tensors": [{"real": np.asarray(t).real.tolist(),
-                         "imag": np.asarray(t).imag.tolist()} for t in res.basis.tensors],
+            "tensors": serialize_tensors(res.basis.tensors),
         }, indent=2))
         (cell / "env.json").write_text(json.dumps({
             "experiment": "qft_unfreeze", "dataset": args.dataset, "ordering": name,
@@ -167,7 +159,7 @@ def main() -> int:
             "grad_tol": args.grad_tol, "loss_tol": args.loss_tol,
             "min_steps": args.min_steps, "max_steps": args.max_steps,
             "batch": len(fixed_batch), "seed": seed,
-            "device": str(chosen), "git_sha": _git_sha(),
+            "device": str(chosen), "git_sha": git_sha(short=False),
         }, indent=2))
 
         manifest_orderings[name] = {
@@ -182,7 +174,7 @@ def main() -> int:
     (out_base / "manifest.json").write_text(json.dumps({
         "experiment": "qft_unfreeze", "dataset": args.dataset, "m": m, "n": n,
         "init": args.init, "init_seed": init_seed,
-        "orderings": manifest_orderings, "git_sha": _git_sha(),
+        "orderings": manifest_orderings, "git_sha": git_sha(short=False),
     }, indent=2))
     print(f"\n[qft_unfreeze] done. Manifest: {out_base / 'manifest.json'}")
     return 0

--- a/experiments/quickdraw_block_size_sweep.py
+++ b/experiments/quickdraw_block_size_sweep.py
@@ -18,10 +18,9 @@ Outputs land in `--out` directly. After the run, cellify into the canonical
 # 20+ classical baselines, so a single visible GPU is fine.
 
 import argparse
-from dataclasses import replace
 
+from pdft_benchmarks.experiment_utils import apply_preset_overrides
 from pdft_benchmarks.pipeline import run_experiment
-from pdft_benchmarks.presets import get_preset
 
 
 TRAINED_BASES = (
@@ -61,17 +60,10 @@ def main():
         print(f"[quickdraw-sweep] unknown bases: {unknown}; valid: {TRAINED_BASES}", file=sys.stderr)
         raise SystemExit(2)
 
-    preset = args.preset
-    if args.no_early_stop or args.epochs is not None:
-        base = get_preset("quickdraw", preset) if isinstance(preset, str) else preset
-        kwargs = {}
-        if args.no_early_stop:
-            kwargs["early_stopping_patience"] = 10**9
-        if args.epochs is not None:
-            kwargs["epochs"] = args.epochs
-        preset = replace(base, **kwargs)
-        print(f"[quickdraw-sweep] preset overrides: epochs={preset.epochs}, "
-              f"patience={preset.early_stopping_patience}")
+    preset = apply_preset_overrides(
+        args.preset, dataset="quickdraw", tag="quickdraw-sweep",
+        no_early_stop=args.no_early_stop, epochs=args.epochs,
+    )
 
     res = run_experiment(
         dataset="quickdraw",

--- a/experiments/quickdraw_pca_vs_block_dct.py
+++ b/experiments/quickdraw_pca_vs_block_dct.py
@@ -20,10 +20,9 @@ image.
 """
 
 import argparse
-from dataclasses import replace
 
+from pdft_benchmarks.experiment_utils import apply_preset_overrides
 from pdft_benchmarks.pipeline import run_experiment
-from pdft_benchmarks.presets import get_preset
 
 
 def main():
@@ -38,17 +37,10 @@ def main():
                         help="Override preset.epochs.")
     args = parser.parse_args()
 
-    preset = args.preset
-    if args.no_early_stop or args.epochs is not None:
-        base = get_preset("quickdraw", preset) if isinstance(preset, str) else preset
-        kwargs = {}
-        if args.no_early_stop:
-            kwargs["early_stopping_patience"] = 10**9
-        if args.epochs is not None:
-            kwargs["epochs"] = args.epochs
-        preset = replace(base, **kwargs)
-        print(f"[quickdraw] preset overrides: epochs={preset.epochs}, "
-              f"patience={preset.early_stopping_patience}")
+    preset = apply_preset_overrides(
+        args.preset, dataset="quickdraw", tag="quickdraw",
+        no_early_stop=args.no_early_stop, epochs=args.epochs,
+    )
 
     res = run_experiment(
         dataset="quickdraw",

--- a/src/pdft_benchmarks/experiment_utils.py
+++ b/src/pdft_benchmarks/experiment_utils.py
@@ -1,0 +1,100 @@
+"""Shared helpers for the standalone drivers in ``experiments/``.
+
+The canonical train+evaluate path is :func:`pdft_benchmarks.pipeline.run_experiment`.
+Several drivers, however, bypass it to do something the pipeline doesn't cover
+(per-stage curricula, frozen-gate sweeps, warm-starts) and therefore persist
+their own result cells. Those drivers had each grown their own copy of three
+small chores: applying the ``--no-early-stop`` / ``--epochs`` CLI overrides to a
+preset, recording the current git revision, and serializing trained complex
+tensors to JSON.
+
+This module hosts those three chores so the drivers can share one
+implementation. Every helper reproduces the exact on-disk bytes the drivers
+emitted before extraction — same JSON layout, same string formats — so existing
+result trees stay reconcilable.
+
+Kept deliberately JAX-free at import time (only :mod:`numpy` is touched, lazily,
+inside :func:`serialize_tensors`) so it is safe to import even in the drivers
+that must set ``CUDA_VISIBLE_DEVICES`` before any JAX import.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import replace
+
+from .presets import Preset, get_preset
+
+
+def apply_preset_overrides(
+    preset: str | Preset,
+    *,
+    dataset: str,
+    tag: str,
+    no_early_stop: bool = False,
+    epochs: int | None = None,
+) -> str | Preset:
+    """Apply the ``--no-early-stop`` / ``--epochs`` CLI overrides to a preset.
+
+    Mirrors the block the ``*_pca_vs_block_dct`` and ``*_block_size_sweep``
+    drivers each carried verbatim:
+
+    - When neither override is requested, ``preset`` is returned **unchanged** —
+      a bare preset-name string stays a string, so a downstream
+      ``run_experiment`` call resolves it exactly as before.
+    - When either override is requested, the preset is resolved via
+      ``get_preset(dataset, ...)`` if it is still a name, the overrides are
+      applied with :func:`dataclasses.replace` (``early_stopping_patience``
+      pinned to ``10**9`` to disable early stopping), and a one-line summary is
+      printed with the ``[tag]`` prefix.
+
+    ``dataset`` is the **preset-registry** key (e.g. ``"div2k_8q"``), which is
+    not always the dataset-loader key passed to ``run_experiment`` (e.g.
+    ``"div2k"``); callers pass the registry key here.
+    """
+    if not no_early_stop and epochs is None:
+        return preset
+    base = get_preset(dataset, preset) if isinstance(preset, str) else preset
+    overrides: dict = {}
+    if no_early_stop:
+        overrides["early_stopping_patience"] = 10**9
+    if epochs is not None:
+        overrides["epochs"] = epochs
+    preset = replace(base, **overrides)
+    print(f"[{tag}] preset overrides: epochs={preset.epochs}, "
+          f"patience={preset.early_stopping_patience}")
+    return preset
+
+
+def git_sha(*, short: bool = True) -> str:
+    """Return the current git HEAD revision, or ``"unknown"`` outside a repo.
+
+    ``short=True`` gives the 7-char ``git rev-parse --short HEAD``;
+    ``short=False`` gives the full 40-char ``git rev-parse HEAD``. The standalone
+    drivers historically recorded the **full** SHA in their env/manifest files,
+    while :func:`pdft_benchmarks.pipeline.run_experiment` records the short one.
+    The flag lets each call site keep its prior format byte-for-byte.
+    """
+    cmd = ["git", "rev-parse"] + (["--short"] if short else []) + ["HEAD"]
+    try:
+        return subprocess.check_output(cmd, text=True).strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def serialize_tensors(tensors) -> list[dict]:
+    """Serialize complex JAX/NumPy tensors to JSON-ready ``{"real", "imag"}`` dicts.
+
+    Reproduces the ``[{"real": [...], "imag": [...]}, ...]`` layout used by the
+    ``trained_*.json`` checkpoints in ``qft_progressive``, ``qft_freeze_sweep``,
+    ``qft_unfreeze``, ``qft_identity_regularization``, and
+    ``div2k_8q_l1_init_anchor``. (``qft_warmstart_blocked`` uses a different
+    flattened ``[[re, im], ...]`` layout and is intentionally left as-is.)
+    """
+    import numpy as np
+
+    return [
+        {"real": np.asarray(t).real.tolist(),
+         "imag": np.asarray(t).imag.tolist()}
+        for t in tensors
+    ]


### PR DESCRIPTION
## Summary

A focused readability pass over `experiments/`. All 11 drivers were already well-documented (module docstrings, `main()`/argparse/exit codes); the real readability cost was ~150 lines of cross-file duplication. This extracts three small chores into a new JAX-free module `src/pdft_benchmarks/experiment_utils.py` and adopts it across the drivers:

- **`apply_preset_overrides()`** — the `--no-early-stop` / `--epochs` override block (resolve preset → `replace()` → print `"[tag] preset overrides: …"`). Adopted by the 4 `run_experiment` delegators (`quickdraw`/`div2k` `*_pca_vs_block_dct` + `*_block_size_sweep`). The `l1_init_anchor` and `identity_regularization` drivers keep their bespoke override blocks — they use always-replace semantics + different print strings, so folding them in would **not** be byte-identical.
- **`git_sha(short=)`** — one implementation with a short/full flag. The standalone drivers recorded the full 40-char `git rev-parse HEAD`; `pipeline.run_experiment` records the short `--short` form. The flag preserves each call site's prior format byte-for-byte. Removes 3 duplicate `_git_sha` defs (`qft_progressive`, `qft_freeze_sweep`, `qft_unfreeze`) + their now-unused `import subprocess`.
- **`serialize_tensors()`** — the `{"real": …, "imag": …}` trained-tensor layout shared by 5 drivers.

**Left untouched on purpose:** `qft_warmstart_blocked.py` already reuses `pipeline`'s git helpers, and its divergent flattened `[[re, im], …]` tensor layout is preserved (changing it would break byte-identity). Net **−68 lines** across 9 drivers.

## Test plan

- [x] `ruff check` clean on the new module + all 9 edited files
- [x] **Byte-identical output verified**: captured `--preset smoke` runs of `quickdraw_pca_vs_block_dct` (delegator) and `qft_progressive` (standalone, `quickdraw_5q`) before vs after on CPU — every `trained_*.json` and `loss_history/*.json` bit-identical; `metrics`/`env`/`manifest` identical once run-time fields (`time`, `device`, `git_sha`) are masked
- [x] Full 40-char SHA format confirmed preserved by `git_sha(short=False)`
- [x] `qft_unfreeze` (`quickdraw_5q`) + `qft_identity_regularization` (`quickdraw`) smoke-run clean
- [x] `--help` builds for all 9 edited drivers
- [x] `pytest -m "not integration and not slow"` → **285 passed, 3 skipped**
- [ ] DIV2K-only paths (`div2k_8q_pca_vs_block_dct`, `div2k_block_size_sweep`, `qft_freeze_sweep`, `div2k_8q_l1_init_anchor`) not run end-to-end (need DIV2K data + GPU); they use the same proven helpers identically and pass `--help` + ruff

🤖 Generated with [Claude Code](https://claude.com/claude-code)