### PR TITLE
Register DCT-IV cosine basis (full-image + block sweep)

### DIFF
--- a/src/pdft_benchmarks/bases.py
+++ b/src/pdft_benchmarks/bases.py
@@ -64,6 +64,8 @@ BASIS_FACTORIES: dict[str, BasisFactory] = {
     "entangled_qft": lambda m, n, seed=0: pdft.EntangledQFTBasis(m=m, n=n, seed=seed),
     "tebd":          lambda m, n, seed=0: pdft.TEBDBasis(m=m, n=n, seed=seed),
     "mera":          lambda m, n, seed=0: pdft.MERABasis(m=m, n=n, seed=seed),
+    # Learnable cosine basis: exact DCT-IV at init, then relaxed (ancilla-free).
+    "dct4":          lambda m, n, seed=0: pdft.DCT4Basis(m=m, n=n),
     # Block topologies (3): default split — inner basis at (m+1)//2.
     # At QuickDraw m=5: inner_m=3 → 8×8 blocks. At DIV2K m=8: inner_m=4 → 16×16 blocks.
     "blocked":       lambda m, n, seed=0: _blocked(m, n, seed, pdft.QFTBasis),
@@ -76,6 +78,14 @@ BASIS_FACTORIES: dict[str, BasisFactory] = {
     "blocked_8":     lambda m, n, seed=0: _blocked(m, n, seed, pdft.QFTBasis,       inner_m=3, inner_n=3),
     "rich_8":        lambda m, n, seed=0: _blocked(m, n, seed, pdft.RichBasis,      inner_m=3, inner_n=3),
     "real_rich_8":   lambda m, n, seed=0: _blocked(m, n, seed, pdft.RealRichBasis,  inner_m=3, inner_n=3),
+    # Learnable ancilla-free DCT-IV inner on b×b blocks — apples-to-apples with
+    # block_dct_b / rich_b / real_rich_b over the HEVC transform-unit sweep
+    # {4,8,16,32}. (dct4_32 is degenerate with full-image dct4 at m=5, so it is
+    # excluded from the QuickDraw grid.)
+    "dct4_4":        lambda m, n, seed=0: _blocked(m, n, seed, pdft.DCT4Basis,      inner_m=2, inner_n=2),
+    "dct4_8":        lambda m, n, seed=0: _blocked(m, n, seed, pdft.DCT4Basis,      inner_m=3, inner_n=3),
+    "dct4_16":       lambda m, n, seed=0: _blocked(m, n, seed, pdft.DCT4Basis,      inner_m=4, inner_n=4),
+    "dct4_32":       lambda m, n, seed=0: _blocked(m, n, seed, pdft.DCT4Basis,      inner_m=5, inner_n=5),
     # Block topologies, fixed 4×4 block size (inner_m=inner_n=2). Sweep
     # extension; spec §6.1.
     "blocked_4":     lambda m, n, seed=0: _blocked(m, n, seed, pdft.QFTBasis,       inner_m=2, inner_n=2),


### PR DESCRIPTION
## Summary

Registers the ancilla-free **DCT-IV** learnable cosine basis (from the companion `pdft` PR) in `BASIS_FACTORIES`:

- `dct4` — full-image `DCT4Basis(m, n)`.
- `dct4_{4,8,16,32}` — DCT-IV inner on b×b blocks via the **stock `BlockedBasis`** (no ancilla wrapping), apples-to-apples with `block_dct_b` / `rich_b` / `real_rich_b` over the HEVC transform-unit sweep.

**+10 lines, one file.** No DCT-II, no ancilla machinery.

## Verification

Registry builds `dct4` (m=3) and block `dct4_{4,8}` (m=8); forward/inverse roundtrip exact (`~1e-15`), confirming the unmodified `BlockedBasis` tiles the ancilla-free DCT-IV directly.

## Benchmark (A800, `generalized`, mean test PSNR dB @ ρ=0.20)

| basis | DIV2K-8q | Quick Draw |
|---|---|---|
| dct4 (full-image) | 33.01 | 29.92 |
| dct4 (block, best over sweep) | 33.36 (@8) | 32.79 (@4) |
| *ref:* RealRich / BlockDCT-8 | 33.69 / 34.01 | 32.37 / 26.63 |

Requires `pdft` `DCT4Basis` (companion PR).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
