### PR TITLE
feat(dct4): DCT-IV experiment suite (drivers + infra + test)

### DIFF
--- a/experiments/dct4_direct_training.py
+++ b/experiments/dct4_direct_training.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""DCT-IV direct-training experiment: progressive gate-unfreezing.
+
+Real-orthogonal counterpart of ``qft_direct_training.py unfreeze``. Can good
+DCT-IV operators be reached by training *directly* (rather than by the warm-start
+of dct4_structure_inclusion.py)? Progressively unfreeze the gates of an
+identity- or random-init DCT4Basis, one gate thawed per stage, training each
+stage to a Riemannian plateau on a fixed batch.
+
+The L1 / identity-regularisation modes of the QFT driver are intentionally
+omitted: that narrative (an L1-to-identity anchor pulling outer gates toward the
+trivial slot) is QFT-specific. DCT-IV's structural skeleton (CNOT / CR_y / Delta)
+has no "identity" headline to anchor to, so only the unfreeze mode transfers.
+
+Note: DCT-IV has ~3x the QFT gate count (214 vs 72 tensors at m=n=8 — the
+CNOT/CR_y skeleton), so each ordering has ~3x the unfreeze stages.
+
+Standalone driver: does NOT use run_experiment; writes its own cells via
+evaluate_basis_shared so metrics-table semantics match the headline cells.
+
+GPU isolation: --gpu sets CUDA_VISIBLE_DEVICES (+ CUDA_DEVICE_ORDER=PCI_BUS_ID)
+BEFORE importing pdft_benchmarks (which transitively imports JAX).
+
+Cells land at results/training/2_direct_training/unfreeze_dct4/<dataset>/.
+
+Usage:
+    python experiments/dct4_direct_training.py --gpu 0 --dataset div2k_8q
+    python experiments/dct4_direct_training.py --gpu 0 --dataset quickdraw_5q --init random
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--gpu", type=int, default=None)
+    parser.add_argument("--dataset", default="quickdraw_5q",
+                        choices=["quickdraw_5q", "div2k_8q", "tuberlin_8q"])
+    parser.add_argument("--orderings", default="bg,lr,rl")
+    parser.add_argument("--batch", type=int, default=None,
+                        help="Fixed batch size. Default: full train set at m=5, else 50.")
+    parser.add_argument("--lr", type=float, default=None, help="Default: preset.lr_peak.")
+    parser.add_argument("--grad-tol", type=float, default=1e-5)
+    parser.add_argument("--loss-tol", type=float, default=1e-5)
+    parser.add_argument("--min-steps", type=int, default=5)
+    parser.add_argument("--max-steps", type=int, default=2000)
+    parser.add_argument("--psnr-every", type=int, default=1,
+                        help="Evaluate per-stage test PSNR only every K stages (the "
+                             "final stage is always evaluated). K>1 cuts the dominant "
+                             "m=8 eval cost; the loss/grad-norm staircase is unaffected.")
+    parser.add_argument("--grad-check-every", type=int, default=1,
+                        help="Run the Riemannian grad-norm probe only every K steps "
+                             "(loss-delta plateau uses the Adam step's free loss every "
+                             "step). K>1 roughly halves the per-step cost at m=8.")
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--init", default="identity", choices=["identity", "random"],
+                        help="Gate initialisation: DCT-IV-family identity (default) or "
+                             "Haar-random real-orthogonal (H/R_y -> SO(2), U4 -> SO(4), "
+                             "Delta CP kept at its real sign).")
+    parser.add_argument("--init-seed", type=int, default=None,
+                        help="Seed for --init random (default: preset.seed). Shared "
+                             "across orderings so they start from the same basis.")
+    parser.add_argument("--preset", default="generalized",
+                        choices=["smoke", "moderate", "generalized"])
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    # GPU isolation BEFORE the pdft/JAX imports.
+    if args.gpu is not None:
+        os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+
+    import jax
+    import numpy as np
+    import pdft
+    import pdft.io  # noqa: F401  (needed by evaluate_basis_shared)
+    from pdft_benchmarks.bases import dct4_identity_basis, family_random_basis
+    from pdft_benchmarks.datasets import load_div2k, load_quickdraw, load_tuberlin
+    from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.experiment_utils import git_sha, serialize_tensors
+    from pdft_benchmarks.presets import get_preset
+    from pdft_benchmarks.unfreeze import dct4_unfreeze_orders, train_progressive_unfreeze
+
+    chosen = jax.devices()[0]
+    print(f"[dct4_unfreeze] device: {chosen} (platform={chosen.platform!r})")
+    if args.gpu is not None and chosen.platform not in ("gpu", "cuda"):
+        print(f"[dct4_unfreeze] FATAL: --gpu {args.gpu} requested but JAX sees "
+              f"platform={chosen.platform!r} (NVML init failure?). Aborting.",
+              file=sys.stderr)
+        return 2
+
+    DATASET_CFG = {
+        "quickdraw_5q": (5, load_quickdraw, "img_size"),
+        "div2k_8q": (8, load_div2k, "size"),
+        "tuberlin_8q": (8, load_tuberlin, "size"),
+    }
+    m_q, loader, size_kw = DATASET_CFG[args.dataset]
+    m = n = m_q
+    preset = get_preset(args.dataset, args.preset)
+    seed = args.seed if args.seed is not None else preset.seed
+    init_seed = args.init_seed if args.init_seed is not None else preset.seed
+    lr = args.lr if args.lr is not None else preset.lr_peak
+    batch = args.batch if args.batch is not None else (preset.n_train if m == 5 else 50)
+
+    train_imgs, test_imgs = loader(n_train=preset.n_train, n_test=preset.n_test,
+                                   seed=seed, **{size_kw: 2 ** m})
+    fixed_batch = [np.asarray(x) for x in train_imgs[:batch]]
+    k_train = max(1, round(2 ** (m + n) * 0.1))
+    loss = pdft.MSELoss(k=k_train)
+    print(f"[dct4_unfreeze] dataset={args.dataset} m=n={m} init={args.init} "
+          f"init_seed={init_seed} batch={len(fixed_batch)} "
+          f"k_train={k_train} lr={lr} max_steps={args.max_steps}")
+
+    def make_basis():
+        if args.init == "random":
+            return family_random_basis("dct4", m, n, init_seed)
+        return dct4_identity_basis(m=m, n=n)
+
+    orders = dct4_unfreeze_orders(m, n)
+    keep_ratios = (0.05, 0.10, 0.15, 0.20)
+
+    out_base = Path(args.out) if args.out else \
+        Path(f"results/training/2_direct_training/unfreeze_dct4/{args.dataset}")
+    out_base.mkdir(parents=True, exist_ok=True)
+
+    manifest_orderings = {}
+    for name in [s.strip() for s in args.orderings.split(",") if s.strip()]:
+        order = orders[name]
+        print(f"\n[dct4_unfreeze] === ordering {name!r}: {len(order)} stages ===")
+        basis = make_basis()
+        n_stages = len(order)
+
+        def stage_psnr(stage, tensors):
+            # Skip the expensive full-test-set eval on intermediate stages when
+            # --psnr-every > 1; always evaluate the final stage.
+            if args.psnr_every > 1 and stage != n_stages and stage % args.psnr_every != 0:
+                return {}
+            b = pdft.DCT4Basis(m=m, n=n, tensors=tensors)
+            metrics, _ = evaluate_basis_shared(b, test_imgs, keep_ratios=keep_ratios)
+            return {"psnr": {f"{r}": float(metrics[str(r)]["mean_psnr"]) for r in keep_ratios}}
+
+        t0 = time.perf_counter()
+        res = train_progressive_unfreeze(
+            basis, fixed_batch, unfreeze_order=order, lr=lr,
+            max_steps_per_stage=args.max_steps, loss=loss,
+            grad_tol=args.grad_tol, loss_tol=args.loss_tol,
+            min_steps_per_stage=args.min_steps, seed=seed,
+            stage_callback=stage_psnr, grad_check_every=args.grad_check_every)
+        elapsed = time.perf_counter() - t0
+        total_steps = res.stages[-1].end_step
+        print(f"[dct4_unfreeze]   {name}: {total_steps} steps, {elapsed:.1f}s, "
+              f"final PSNR@0.2={res.stages[-1].extra['psnr']['0.2']:.3f} dB")
+
+        cell = out_base / name
+        cell.mkdir(parents=True, exist_ok=True)
+        (cell / "trace.json").write_text(json.dumps({
+            "dataset": args.dataset, "ordering": name, "m": m, "n": n,
+            "lr": lr, "grad_tol": args.grad_tol, "loss_tol": args.loss_tol,
+            "min_steps": args.min_steps, "max_steps": args.max_steps,
+            "batch": len(fixed_batch), "k_train": k_train,
+            "steps": res.trace,
+            "stages": [vars(s) for s in res.stages],
+            "git_sha": git_sha(short=False),
+        }, indent=2))
+        (cell / "trained_final.json").write_text(json.dumps({
+            "ordering": name, "m": int(res.basis.m), "n": int(res.basis.n),
+            "tensors": serialize_tensors(res.basis.tensors),
+        }, indent=2))
+        (cell / "env.json").write_text(json.dumps({
+            "experiment": "dct4_unfreeze", "dataset": args.dataset, "ordering": name,
+            "init": args.init, "init_seed": init_seed, "lr": lr,
+            "grad_tol": args.grad_tol, "loss_tol": args.loss_tol,
+            "min_steps": args.min_steps, "max_steps": args.max_steps,
+            "batch": len(fixed_batch), "seed": seed,
+            "device": str(chosen), "git_sha": git_sha(short=False),
+        }, indent=2))
+
+        manifest_orderings[name] = {
+            "n_stages": len(res.stages), "total_steps": total_steps,
+            "elapsed_seconds": elapsed,
+            "trigger_counts": {tr: sum(1 for s in res.stages if s.trigger == tr)
+                               for tr in ("grad_norm", "loss_delta", "max_steps")},
+            "final_loss": res.stages[-1].final_loss,
+            "final_psnr": res.stages[-1].extra["psnr"],
+        }
+
+    (out_base / "manifest.json").write_text(json.dumps({
+        "experiment": "dct4_unfreeze", "dataset": args.dataset, "m": m, "n": n,
+        "init": args.init, "init_seed": init_seed,
+        "orderings": manifest_orderings, "git_sha": git_sha(short=False),
+    }, indent=2))
+    print(f"\n[dct4_unfreeze] done. Manifest: {out_base / 'manifest.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/dct4_freeze_sweep.py
+++ b/experiments/dct4_freeze_sweep.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Drive the dct4_freeze_sweep experiment on DIV2K-8q.
+
+Real-orthogonal counterpart of ``qft_freeze_sweep.py``. Two cells using the
+upstream pdft.train_basis_batched(..., frozen_indices=...) parameter:
+
+  freeze_outer:  DCT4Basis(8, 8) identity init, freeze the 180 outer gates,
+                 train the 34 inner gates. Operator-equivalent to a trained
+                 BlockedBasis(DCT4(3,3), 5, 5) (the inner-3 block), since the
+                 frozen outer recursion levels stay at identity.
+
+  freeze_inner:  DCT4Basis(8, 8) identity init, freeze 34 inner gates,
+                 train 180 outer gates. Vice-versa configuration probing the
+                 standalone compression signal of the inter-/cross-block
+                 structure.
+
+Inner-block boundary fixed at (inner_m=3, inner_n=3) to match the blocked
+DCT-IV anchor's structural form.
+
+Cells land at results/training/_archive/dct4_freeze_sweep/div2k_8q/_runs/{freeze_outer,freeze_inner}/.
+Manifest at results/training/_archive/dct4_freeze_sweep/div2k_8q/manifest.json.
+
+Usage:
+    python experiments/dct4_freeze_sweep.py --gpu 0 [--epochs 112]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import replace
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--gpu", type=int, default=None)
+    parser.add_argument("--epochs", type=int, default=112,
+                        help="Epoch budget per cell (default 112 = 1008 steps).")
+    parser.add_argument("--out-base", type=str, default=None)
+    parser.add_argument("--dataset", type=str, default="div2k_8q",
+                        choices=["div2k_8q"])
+    parser.add_argument("--preset", type=str, default="generalized",
+                        choices=["smoke", "moderate", "generalized"])
+    parser.add_argument("--inner-m", type=int, default=3)
+    parser.add_argument("--inner-n", type=int, default=3)
+    parser.add_argument("--mode", type=str, default="both",
+                        choices=["both", "freeze_outer", "freeze_inner"],
+                        help="Which cell(s) to train. Default 'both'.")
+    args = parser.parse_args()
+
+    if args.gpu is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+
+    import jax
+    import pdft
+    import pdft.io  # noqa: F401
+    from pdft_benchmarks.bases import (
+        dct4_identity_basis,
+        dct4_inner_outer_indices,
+    )
+    from pdft_benchmarks.datasets import load_div2k
+    from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.experiment_utils import git_sha, serialize_tensors
+    from pdft_benchmarks.presets import get_preset
+
+    # GPU fail-fast — same pattern as the qft_progressive driver.
+    devices = jax.devices()
+    chosen = devices[0]
+    print(f"[dct4_freeze_sweep] JAX devices: {devices}")
+    print(f"[dct4_freeze_sweep] chosen device: {chosen} (platform={chosen.platform!r})")
+    if args.gpu is not None and chosen.platform not in ("gpu", "cuda"):
+        print(
+            f"[dct4_freeze_sweep] FATAL: --gpu {args.gpu} requested but JAX "
+            f"sees platform={chosen.platform!r}. Aborting.",
+            file=sys.stderr,
+        )
+        return 2
+
+    preset = get_preset(args.dataset, args.preset)
+    preset = replace(preset, epochs=args.epochs, early_stopping_patience=10**9)
+    print(f"[dct4_freeze_sweep] dataset={args.dataset}, epochs={preset.epochs}, "
+          f"seed={preset.seed}, inner=({args.inner_m},{args.inner_n})")
+
+    m = n = 8
+    train_imgs_np, test_imgs_np = load_div2k(
+        n_train=preset.n_train, n_test=preset.n_test,
+        seed=preset.seed, size=2**m,
+    )
+    k_train = max(1, round(2 ** (m + n) * 0.1))
+    print(f"[dct4_freeze_sweep] m=n={m}, k_train={k_train}, "
+          f"{len(train_imgs_np)} train, {len(test_imgs_np)} test images")
+
+    inner_idx, outer_idx = dct4_inner_outer_indices(
+        m=m, n=n, inner_m=args.inner_m, inner_n=args.inner_n,
+    )
+    assert len(inner_idx) == 34 and len(outer_idx) == 180, \
+        f"unexpected partition: {len(inner_idx)} inner + {len(outer_idx)} outer"
+    print(f"[dct4_freeze_sweep] inner indices ({len(inner_idx)}): {inner_idx}")
+    print(f"[dct4_freeze_sweep] outer indices ({len(outer_idx)}): "
+          f"first 10 = {outer_idx[:10]} ... last 3 = {outer_idx[-3:]}")
+
+    out_base = Path(args.out_base) if args.out_base else \
+        Path(f"results/training/_archive/dct4_freeze_sweep/{args.dataset}/_runs")
+    out_base.mkdir(parents=True, exist_ok=True)
+
+    cell_specs = []
+    if args.mode in ("both", "freeze_outer"):
+        cell_specs.append({
+            "name": "freeze_outer",
+            "basis_name": "dct4_freeze_outer",
+            "frozen_indices": outer_idx,
+            "trainable_count": len(inner_idx),
+            "description": (
+                "DCT4(8,8) identity init, freeze 180 outer gates, train 34 "
+                "inner. Operator-equivalent to BlockedBasis(DCT4(3,3), 5, 5)."
+            ),
+        })
+    if args.mode in ("both", "freeze_inner"):
+        cell_specs.append({
+            "name": "freeze_inner",
+            "basis_name": "dct4_freeze_inner",
+            "frozen_indices": inner_idx,
+            "trainable_count": len(outer_idx),
+            "description": (
+                "DCT4(8,8) identity init, freeze 34 inner gates, train 180 "
+                "outer. Vice-versa configuration."
+            ),
+        })
+
+    summaries: list[dict] = []
+    for spec in cell_specs:
+        out_dir = out_base / spec["name"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "loss_history").mkdir(parents=True, exist_ok=True)
+
+        print(f"\n[dct4_freeze_sweep] === cell {spec['name']!r} "
+              f"({spec['trainable_count']} trainable / "
+              f"{len(spec['frozen_indices'])} frozen) -> {out_dir} ===")
+        print(f"[dct4_freeze_sweep]   {spec['description']}")
+
+        basis = dct4_identity_basis(m=m, n=n)
+
+        t0 = time.perf_counter()
+        result = pdft.train_basis_batched(
+            basis,
+            dataset=train_imgs_np,
+            loss=pdft.MSELoss(k=k_train),
+            epochs=preset.epochs,
+            batch_size=preset.batch_size,
+            optimizer=preset.optimizer,
+            validation_split=preset.validation_split,
+            early_stopping_patience=preset.early_stopping_patience,
+            warmup_frac=preset.warmup_frac,
+            lr_peak=preset.lr_peak,
+            lr_final=preset.lr_final,
+            max_grad_norm=preset.max_grad_norm,
+            shuffle=True, seed=preset.seed,
+            val_every_k_epochs=preset.val_every_k_epochs,
+            frozen_indices=spec["frozen_indices"],
+        )
+        elapsed = time.perf_counter() - t0
+        steps = int(result.steps)
+        epochs_done = int(result.epochs_completed)
+        print(f"[dct4_freeze_sweep]   trained in {elapsed:.1f}s, "
+              f"steps={steps}, epochs={epochs_done}")
+
+        eval_metrics, _ = evaluate_basis_shared(
+            result.basis, test_imgs_np,
+            keep_ratios=(0.05, 0.10, 0.15, 0.20),
+        )
+        psnr20 = float(eval_metrics["0.2"]["mean_psnr"])
+        Lf = float(result.val_history[-1]) if len(result.val_history) > 0 else float("nan")
+        print(f"[dct4_freeze_sweep]   PSNR @ rho=0.20: {psnr20:.3f} dB, "
+              f"val MSE final: {Lf:.3f}")
+
+        # Sanity check: frozen tensors haven't moved from identity.
+        from pdft_benchmarks.bases import dct4_identity_basis as _ref
+        ref_tensors = _ref(m=m, n=n).tensors
+        import jax.numpy as jnp
+        for i in spec["frozen_indices"]:
+            diff = float(jnp.max(jnp.abs(result.basis.tensors[i] - ref_tensors[i])))
+            assert diff == 0.0, (
+                f"frozen index {i} drifted by {diff} — "
+                f"frozen_indices semantics broken!"
+            )
+        print(f"[dct4_freeze_sweep]   verified: all {len(spec['frozen_indices'])} "
+              f"frozen tensors are bit-exactly at identity.")
+
+        basis_name = spec["basis_name"]
+        (out_dir / "metrics.json").write_text(json.dumps({
+            basis_name: {
+                "metrics": eval_metrics,
+                "time": elapsed,
+                "_pdft_py": {
+                    "mode": spec["name"],
+                    "trainable_count": int(spec["trainable_count"]),
+                    "frozen_count": int(len(spec["frozen_indices"])),
+                    "steps": steps,
+                    "epochs_completed": epochs_done,
+                    "device": str(jax.devices()[0]),
+                    "n_test": int(len(test_imgs_np)),
+                }
+            }
+        }, indent=2))
+        (out_dir / "loss_history" / f"{basis_name}_loss.json").write_text(json.dumps({
+            "step_losses": [float(x) for x in result.loss_history],
+            "val_losses": [float(x) for x in result.val_history],
+            "epochs_completed": epochs_done,
+            "steps": steps,
+        }, indent=2))
+        (out_dir / f"trained_{basis_name}.json").write_text(json.dumps({
+            "mode": spec["name"],
+            "m": m, "n": n,
+            "inner_m": int(args.inner_m), "inner_n": int(args.inner_n),
+            "frozen_indices": list(spec["frozen_indices"]),
+            "tensors": serialize_tensors(result.basis.tensors),
+        }, indent=2))
+        (out_dir / "env.json").write_text(json.dumps({
+            "experiment": "dct4_freeze_sweep",
+            "cell": spec["name"],
+            "epochs_used": epochs_done,
+            "steps_used": steps,
+            "trainable_count": int(spec["trainable_count"]),
+            "frozen_count": int(len(spec["frozen_indices"])),
+            "inner_m": int(args.inner_m), "inner_n": int(args.inner_n),
+            "init_policy": "identity",
+            "preset_name": args.preset,
+            "preset_epochs": int(args.epochs),
+            "device": str(jax.devices()[0]),
+            "git_sha": git_sha(short=False),
+        }, indent=2))
+
+        summaries.append({
+            "cell": spec["name"], "basis_name": basis_name,
+            "trainable_count": int(spec["trainable_count"]),
+            "frozen_count": int(len(spec["frozen_indices"])),
+            "psnr_rho_020": psnr20,
+            "val_mse_final": Lf,
+            "steps": steps,
+            "elapsed_seconds": float(elapsed),
+        })
+
+    manifest_path = out_base.parent / "manifest.json"
+    manifest_path.write_text(json.dumps({
+        "experiment": "dct4_freeze_sweep",
+        "dataset": args.dataset,
+        "epochs": int(args.epochs),
+        "inner_m": int(args.inner_m), "inner_n": int(args.inner_n),
+        "cells": summaries,
+        "git_sha": git_sha(short=False),
+    }, indent=2))
+
+    print(f"\n[dct4_freeze_sweep] complete. Manifest: {manifest_path}")
+    print("[dct4_freeze_sweep] PSNR @ rho=0.20:")
+    for s in summaries:
+        print(f"  {s['cell']:<14s} ({s['trainable_count']:>3d} trainable, "
+              f"{s['frozen_count']:>3d} frozen): {s['psnr_rho_020']:.3f} dB "
+              f"(val MSE {s['val_mse_final']:.1f})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/dct4_seed_sweep.py
+++ b/experiments/dct4_seed_sweep.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Random-seed variance sweep for the progressive gate-unfreeze DCT-IV (DIV2K-8q).
+
+Real-orthogonal counterpart of ``qft_seed_sweep.py``. Trains the DCT4(m, n)
+gate-unfreeze operator from Haar-random init, top-20% coefficient objective,
+over many seeds and the three unfreeze orderings (`bg`/`lr`/`rl`). Each seed `s`
+reseeds EVERYTHING trainable:
+
+  - the Haar gate init               (family_random_basis("dct4", m, n, s))
+  - the 50-image training batch      (subsampled from the fixed 500-image train
+                                      pool with np.random.default_rng(s))
+  - the training RNG                 (train_progressive_unfreeze seed=s)
+
+The held-out TEST set is held FIXED (canonical seed-42 50 images) so endpoint
+PSNR variance reflects the trained model, not which test images were drawn.
+
+Note: DCT-IV has ~3x the QFT gate count (214 vs 72 tensors at m=n=8 — the
+CNOT/CR_y skeleton), so each ordering has ~3x the unfreeze stages. Endpoint PSNR
+is the only full-test eval per run, so the extra cost is in training, not eval.
+
+Each (ordering, seed) run is an independent, atomically-checkpointed cell:
+
+    <out>/_runs/<ordering>/seed_<NNN>.json        committed endpoint cell
+    <out>/_runs/<ordering>/seed_<NNN>_trace.json  full per-step loss trace
+                                                  (local; default on; --no-trace)
+
+A finished cell is skipped on re-invocation (unless --force), so a parallel
+dispatcher can fan many jobs across GPUs, crash, and resume by filling only the
+gaps. `--aggregate-only` rolls the cells up into <out>/seed_sweep.json without
+any training (mean / std / min / max / Shapiro-p per ordering per keep ratio).
+
+Usage:
+    # one cell
+    python experiments/dct4_seed_sweep.py --gpu 0 --orderings bg --seeds 7
+    # a slice, sequentially, on one GPU
+    python experiments/dct4_seed_sweep.py --gpu 0 --orderings bg,lr,rl --seeds 1-5
+    # roll up whatever cells exist (no GPU needed)
+    python experiments/dct4_seed_sweep.py --aggregate-only --seeds 1-100
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def _parse_seeds(spec: str) -> list[int]:
+    """Parse "1-100" / "1,2,5" / "1-10,42" into a sorted unique seed list."""
+    seeds: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo, hi = part.split("-", 1)
+            seeds.update(range(int(lo), int(hi) + 1))
+        else:
+            seeds.add(int(part))
+    return sorted(seeds)
+
+
+def _atomic_write_json(path: Path, obj) -> None:
+    """Write JSON to `path` atomically (tmp + os.replace) so a crash never
+    leaves a half-written checkpoint that the resume path would trust."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj, indent=2))
+    os.replace(tmp, path)
+
+
+def _cell_path(out_base: Path, ordering: str, seed: int) -> Path:
+    return out_base / "_runs" / ordering / f"seed_{seed:03d}.json"
+
+
+def _try_claim(cell: Path, stale_seconds: float = 14400) -> bool:
+    """Atomically claim a (ordering, seed) so a *second* dispatcher's driver
+    won't redundantly run the same seed where the forward/reverse sweeps cross
+    (mainly on `lr`). Returns True if we may run it, False only if another LIVE
+    driver currently holds the claim.
+
+    Conservative by design: on ANY doubt (claim is stale from a crashed run,
+    unreadable, or a race) it returns True. A redundant run is harmless (atomic
+    last-writer-wins), whereas a wrongly-skipped seed would be missing from the
+    set — so we always err toward running.
+    """
+    claim = cell.with_suffix(".claim")
+    try:
+        fd = os.open(claim, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        os.write(fd, str(int(time.time())).encode())
+        os.close(fd)
+        return True
+    except FileExistsError:
+        try:
+            fresh = (time.time() - os.path.getmtime(claim)) < stale_seconds
+        except OSError:
+            return True
+        if fresh:
+            return False            # a live driver owns it -> skip
+        try:
+            os.utime(claim, None)   # stale (crashed run) -> take it over
+        except OSError:
+            pass
+        return True
+    except OSError:
+        return True
+
+
+def _release_claim(cell: Path) -> None:
+    try:
+        cell.with_suffix(".claim").unlink()
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Aggregation (no GPU; reusable from --aggregate-only and from the dispatcher).
+# ---------------------------------------------------------------------------
+def aggregate(out_base: Path, orderings: list[str], seeds: list[int],
+              keep_ratios: tuple[float, ...], dataset: str,
+              topk_ratio: float, data_seed: int) -> dict:
+    """Roll up every existing seed cell into a single summary dict and write it
+    to <out_base>/seed_sweep.json. Missing cells are skipped (and counted)."""
+    import numpy as np
+
+    def _stats(vals: list[float]) -> dict:
+        a = np.asarray(vals, dtype=np.float64)
+        out = {"mean": float(a.mean()), "std": float(a.std(ddof=1) if a.size > 1 else 0.0),
+               "min": float(a.min()), "max": float(a.max()), "n": int(a.size)}
+        # Shapiro-Wilk normality (needs >=3 points and some spread).
+        out["shapiro_p"] = None
+        if a.size >= 3 and a.std() > 0:
+            try:
+                from scipy.stats import shapiro
+                out["shapiro_p"] = float(shapiro(a).pvalue)
+            except Exception:  # noqa: BLE001 — scipy optional / degenerate input
+                pass
+        return out
+
+    per_ordering: dict[str, dict] = {}
+    missing: dict[str, list[int]] = {}
+    for ordering in orderings:
+        per_seed: dict[str, dict] = {}
+        miss: list[int] = []
+        for s in seeds:
+            cell = _cell_path(out_base, ordering, s)
+            if not cell.exists():
+                miss.append(s)
+                continue
+            data = json.loads(cell.read_text())
+            per_seed[str(s)] = data["psnr"]
+        agg = {}
+        for kr in keep_ratios:
+            key = str(kr)
+            vals = [v[key] for v in per_seed.values() if key in v]
+            if vals:
+                agg[key] = _stats(vals)
+        per_ordering[ordering] = {"per_seed": per_seed, "agg": agg}
+        if miss:
+            missing[ordering] = miss
+
+    summary = {
+        "dataset": dataset, "init": "random", "topk_ratio": topk_ratio,
+        "data_seed_fixed_test": data_seed, "keep_ratios": list(keep_ratios),
+        "seeds": seeds, "n_seeds": len(seeds),
+        "per_ordering": per_ordering,
+        "missing": missing,
+    }
+    _atomic_write_json(out_base / "seed_sweep.json", summary)
+    return summary
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--gpu", type=int, default=None,
+                   help="GPU index. Sets CUDA_VISIBLE_DEVICES before any pdft/jax import.")
+    p.add_argument("--dataset", default="div2k_8q",
+                   choices=["div2k_8q", "quickdraw_5q", "tuberlin_8q"])
+    p.add_argument("--orderings", default="bg,lr,rl")
+    p.add_argument("--seeds", default="1-100",
+                   help='Seed spec: "1-100" range, "1,2,5" list, or a mix.')
+    p.add_argument("--topk-ratio", type=float, default=0.20,
+                   help="Training objective: keep top fraction of coefficients "
+                        "in the MSE loss. Default 0.20 (the headline is 0.10).")
+    p.add_argument("--batch", type=int, default=None,
+                   help="Training batch size (subsampled per seed). Default: full "
+                        "train set at m=5, else 50.")
+    p.add_argument("--lr", type=float, default=None, help="Default: preset.lr_peak.")
+    p.add_argument("--grad-tol", type=float, default=1e-5)
+    p.add_argument("--loss-tol", type=float, default=1e-5)
+    p.add_argument("--min-steps", type=int, default=5)
+    p.add_argument("--max-steps", type=int, default=2000)
+    p.add_argument("--grad-check-every", type=int, default=5,
+                   help="Riemannian grad-norm probe cadence (loss-delta plateau "
+                        "uses the free per-step loss). 5 ~halves per-step cost.")
+    p.add_argument("--out", default=None,
+                   help="Output base. Default results/training/2_direct_training/"
+                        "random_seed_dct4/<dataset>.")
+    p.add_argument("--no-trace", action="store_true", default=False,
+                   help="Skip the full per-step trace file (keeps only the "
+                        "compact endpoint cell with per-stage final losses).")
+    p.add_argument("--no-tensors", action="store_true", default=False,
+                   help="Skip saving the trained DCT-IV operator (trained_seed_*.json). "
+                        "Each is ~30-60 KB and regenerable from the seed.")
+    p.add_argument("--force", action="store_true", default=False,
+                   help="Retrain cells even if their seed_<NNN>.json exists.")
+    p.add_argument("--aggregate-only", action="store_true", default=False,
+                   help="Skip training; just roll existing cells into "
+                        "seed_sweep.json. No GPU needed.")
+    args = p.parse_args()
+
+    DATASET_CFG = {
+        "quickdraw_5q": (5, "load_quickdraw", "img_size"),
+        "div2k_8q": (8, "load_div2k", "size"),
+        "tuberlin_8q": (8, "load_tuberlin", "size"),
+    }
+    m_q, loader_name, size_kw = DATASET_CFG[args.dataset]
+    m = n = m_q
+    orderings = [s.strip() for s in args.orderings.split(",") if s.strip()]
+    seeds = _parse_seeds(args.seeds)
+    keep_ratios = (0.05, 0.10, 0.15, 0.20)
+    out_base = Path(args.out) if args.out else \
+        Path(f"results/training/2_direct_training/random_seed_dct4/{args.dataset}")
+    out_base.mkdir(parents=True, exist_ok=True)
+
+    # --- aggregate-only short-circuit: no JAX, no GPU. -----------------------
+    if args.aggregate_only:
+        s = aggregate(out_base, orderings, seeds, keep_ratios,
+                      args.dataset, args.topk_ratio, data_seed=42)
+        done = sum(len(v["per_seed"]) for v in s["per_ordering"].values())
+        print(f"[dct4_seed_sweep] aggregated {done} cells -> {out_base/'seed_sweep.json'}")
+        for o in orderings:
+            a = s["per_ordering"][o]["agg"].get("0.2")
+            if a:
+                print(f"  {o}: PSNR@.20 mean={a['mean']:.3f} std={a['std']:.3f} "
+                      f"min={a['min']:.3f} max={a['max']:.3f} n={a['n']} "
+                      f"shapiro_p={a['shapiro_p']}")
+        return 0
+
+    if args.gpu is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+        os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+
+    # IMPORTANT: imports AFTER the env var so JAX binds the requested device.
+    import jax
+    import numpy as np
+    import pdft
+    import pdft.io  # noqa: F401 — needed by evaluate_basis_shared
+    from pdft_benchmarks import datasets as ds_mod
+    from pdft_benchmarks.bases import family_random_basis
+    from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.experiment_utils import git_sha, serialize_tensors
+    from pdft_benchmarks.presets import get_preset
+    from pdft_benchmarks.unfreeze import dct4_unfreeze_orders, train_progressive_unfreeze
+
+    chosen = jax.devices()[0]
+    print(f"[dct4_seed_sweep] device: {chosen} (platform={chosen.platform!r})")
+    if args.gpu is not None and chosen.platform not in ("gpu", "cuda"):
+        print(f"[dct4_seed_sweep] FATAL: --gpu {args.gpu} requested but JAX sees "
+              f"platform={chosen.platform!r} (NVML init failure?). Aborting to "
+              f"avoid a silent CPU run.", file=sys.stderr)
+        return 2
+
+    preset = get_preset(args.dataset, "generalized")
+    lr = args.lr if args.lr is not None else preset.lr_peak
+    batch = args.batch if args.batch is not None else (preset.n_train if m == 5 else 50)
+    loader = getattr(ds_mod, loader_name)
+
+    # Canonical split (seed 42): fixes BOTH the 500-image train pool and the
+    # 50-image held-out test set. Per-seed runs subsample the training batch
+    # from `train_pool` but always evaluate on this same `test_imgs`.
+    train_pool, test_imgs = loader(n_train=preset.n_train, n_test=preset.n_test,
+                                   seed=42, **{size_kw: 2 ** m})
+    k_train = max(1, round(2 ** (m + n) * args.topk_ratio))
+    loss = pdft.MSELoss(k=k_train)
+    orders = dct4_unfreeze_orders(m, n)
+    print(f"[dct4_seed_sweep] dataset={args.dataset} m=n={m} topk_ratio={args.topk_ratio} "
+          f"k_train={k_train} batch={batch} lr={lr} "
+          f"orderings={orderings} seeds=[{seeds[0]}..{seeds[-1]}] n={len(seeds)}")
+
+    for ordering in orderings:
+        order = orders[ordering]
+        n_stages = len(order)
+        cell_dir = out_base / "_runs" / ordering
+        cell_dir.mkdir(parents=True, exist_ok=True)
+
+        for seed in seeds:
+            cell = _cell_path(out_base, ordering, seed)
+            if cell.exists() and not args.force:
+                print(f"[dct4_seed_sweep] skip {ordering}/seed_{seed:03d} (exists)")
+                continue
+            if not args.force and not _try_claim(cell):
+                print(f"[dct4_seed_sweep] skip {ordering}/seed_{seed:03d} (claimed by another worker)")
+                continue
+            if cell.exists() and not args.force:  # cell landed while we claimed
+                _release_claim(cell)
+                continue
+
+            # Per-seed training batch: subsample `batch` of the fixed train pool.
+            rng = np.random.default_rng(seed)
+            batch_idx = sorted(int(i) for i in
+                               rng.choice(len(train_pool), size=batch, replace=False))
+            fixed_batch = [np.asarray(train_pool[i]) for i in batch_idx]
+            basis = family_random_basis("dct4", m, n, seed)
+
+            def stage_psnr(stage, tensors, _n=n_stages):
+                if stage != _n:  # endpoint only — skip the per-stage full-test evals
+                    return {}
+                b = pdft.DCT4Basis(m=m, n=n, tensors=tensors)
+                metrics, _ = evaluate_basis_shared(b, test_imgs, keep_ratios=keep_ratios)
+                return {"psnr": {f"{r}": float(metrics[str(r)]["mean_psnr"])
+                                 for r in keep_ratios}}
+
+            t0 = time.perf_counter()
+            res = train_progressive_unfreeze(
+                basis, fixed_batch, unfreeze_order=order, lr=lr,
+                max_steps_per_stage=args.max_steps, loss=loss,
+                grad_tol=args.grad_tol, loss_tol=args.loss_tol,
+                min_steps_per_stage=args.min_steps, seed=seed,
+                stage_callback=stage_psnr, grad_check_every=args.grad_check_every)
+            elapsed = time.perf_counter() - t0
+            psnr = res.stages[-1].extra["psnr"]
+            total_steps = res.stages[-1].end_step
+            print(f"[dct4_seed_sweep] {ordering}/seed_{seed:03d}: {total_steps} steps, "
+                  f"{elapsed:.1f}s, PSNR@.20={psnr['0.2']:.3f} dB")
+
+            _atomic_write_json(cell, {
+                "dataset": args.dataset, "ordering": ordering, "seed": seed,
+                "m": m, "n": n, "init": "random",
+                "topk_ratio": args.topk_ratio, "k_train": k_train,
+                "lr": lr, "batch": batch, "train_batch_idx": batch_idx,
+                "max_steps": args.max_steps, "grad_check_every": args.grad_check_every,
+                "psnr": psnr,
+                "final_loss": res.stages[-1].final_loss,
+                "total_steps": total_steps,
+                "per_stage_final_loss": [s.final_loss for s in res.stages],
+                "trigger_counts": {tr: sum(1 for s in res.stages if s.trigger == tr)
+                                   for tr in ("grad_norm", "loss_delta", "max_steps")},
+                "elapsed_seconds": elapsed,
+                "device": str(chosen), "git_sha": git_sha(short=False),
+            })
+            if not args.no_trace:
+                _atomic_write_json(cell.with_name(f"seed_{seed:03d}_trace.json"), {
+                    "ordering": ordering, "seed": seed,
+                    "steps": res.trace,
+                })
+            if not args.no_tensors:
+                # The trained DCT-IV operator itself (~30-60 KB). Regenerable from
+                # the seed, but saved so reconstruction / re-eval don't need a
+                # full rerun. Schema matches the unfreeze trained_*.json cells.
+                _atomic_write_json(cell.with_name(f"trained_seed_{seed:03d}.json"), {
+                    "ordering": ordering, "seed": seed,
+                    "m": int(res.basis.m), "n": int(res.basis.n),
+                    "tensors": serialize_tensors(res.basis.tensors),
+                })
+            _release_claim(cell)
+
+    # Refresh the rolled-up summary so a single-process run also produces it.
+    aggregate(out_base, orderings, seeds, keep_ratios,
+              args.dataset, args.topk_ratio, data_seed=42)
+    print(f"[dct4_seed_sweep] done. Summary: {out_base/'seed_sweep.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/dct4_structure_inclusion.py
+++ b/experiments/dct4_structure_inclusion.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Warm-start full DCT4(m, n) from a TRAINED BlockedBasis(DCT4(m_in, n_in), ...)
+and re-train all m+n axis parameters from there.
+
+Real-orthogonal counterpart of ``qft_structure_inclusion.py``. Demonstrates that
+the trained blocked optimum is reachable from the larger DCT-IV family via
+warm-start: after re-training, the unblocked DCT4(m, n) retains the trained
+blocked PSNR (within run-to-run noise) — i.e. training from the warm-start does
+not push the operator out of the blocked basin.
+
+Upstream dependency (mirrors the QFT driver's ``blocked_8`` input): the trained
+``dct4_8`` blocked cell must already exist. Produce it by training the ``dct4_8``
+basis (= BlockedBasis(DCT4(3,3), 5, 5)) in the structure pipeline first; its
+``trained_dct4_8.json`` is what this driver warm-starts from. ``load_trained_basis``
+keys the inner topology off the filename stem, so the file MUST stay named
+``trained_dct4_8.json``.
+
+Pipeline (self-contained, does NOT use pdft_benchmarks.run_experiment):
+
+  1. Load the previously-trained blocked basis from
+       results/structure/<src_experiment>/by_basis/dct4_8/trained_dct4_8.json
+  2. Construct a DCT4Basis(m, n) whose initial operator equals the trained
+     blocked one bit-exactly (via bases.dct4_warm_from_trained_blocked).
+  3. Sanity-check bit-exactness on a random complex test input.
+  4. Train under the same preset/budget the headline experiment used, with
+     all m+n axis parameters trainable.
+  5. Evaluate at the headline keep-ratios and write a cell layout matching
+     the existing by_basis convention.
+
+Outputs land at:
+  results/training/1_structure_inclusion/by_basis/<basis_name>/
+    metrics.json, env.json, trained_<basis_name>.json, loss_history/
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+# (dataset, m, n, src trained_*.json, src dataset-loader name, output basis name)
+DATASETS: dict[str, dict] = {
+    "div2k_8q": {
+        "m": 8, "n": 8,
+        "load_dataset": "div2k",
+        "preset_namespace": "div2k_8q",
+        "trained_blocked_path": (
+            "results/structure/div2k_8q_pca_vs_block_dct/by_basis/dct4_8/"
+            "trained_dct4_8.json"
+        ),
+        "output_basis_name": "dct4_warmstart_blocked_8",
+    },
+    "quickdraw": {
+        "m": 5, "n": 5,
+        "load_dataset": "quickdraw",
+        "preset_namespace": "quickdraw",
+        "trained_blocked_path": (
+            "results/structure/quickdraw_pca_vs_block_dct/by_basis/dct4_8/"
+            "trained_dct4_8.json"
+        ),
+        "output_basis_name": "dct4_warmstart_blocked",
+    },
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--dataset", choices=list(DATASETS), required=True)
+    parser.add_argument("--gpu", type=int, default=None,
+                        help="GPU index. Sets CUDA_VISIBLE_DEVICES before JAX import.")
+    parser.add_argument(
+        "--out",
+        default="results/training/1_structure_inclusion",
+        help="Output root. Cell will land at <out>/by_basis/<basis_name>/.",
+    )
+    parser.add_argument("--epochs", type=int, default=112,
+                        help="Headline budget = 112 epochs ≈ 1008 steps.")
+    parser.add_argument("--preset", default="generalized",
+                        choices=["smoke", "moderate", "generalized"])
+    args = parser.parse_args()
+
+    # CRITICAL: set CUDA_VISIBLE_DEVICES BEFORE importing pdft_benchmarks.
+    if args.gpu is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+
+    cfg = DATASETS[args.dataset]
+
+    # Imports below trigger JAX device discovery; must come AFTER the env var.
+    import json
+    import time
+    from dataclasses import replace
+    from datetime import datetime, timezone
+
+    import jax
+    import jax.numpy as jnp
+    import numpy as np
+
+    import pdft  # noqa: F401  -- ensures jax_enable_x64
+
+    from pdft_benchmarks._loading import load_trained_basis
+    from pdft_benchmarks._training import train_one_basis_batched
+    from pdft_benchmarks.bases import dct4_warm_from_trained_blocked
+    from pdft_benchmarks.datasets import load as load_dataset
+    from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.pipeline import _select_device, _git_sha, _git_branch
+    from pdft_benchmarks.presets import get_preset
+
+    out_root = Path(args.out)
+    basis_name = cfg["output_basis_name"]
+    cell_dir = out_root / "by_basis" / basis_name
+    cell_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. Load trained blocked basis.
+    trained_blocked_path = Path(cfg["trained_blocked_path"])
+    if not trained_blocked_path.is_file():
+        print(f"[warmstart] missing trained blocked file: {trained_blocked_path}",
+              file=sys.stderr)
+        return 2
+    print(f"[warmstart] loading trained blocked basis from {trained_blocked_path}")
+    trained_blocked = load_trained_basis(trained_blocked_path)
+    print(f"[warmstart]   inner type={type(trained_blocked.inner).__name__}, "
+          f"inner m={trained_blocked.inner.m} n={trained_blocked.inner.n}, "
+          f"block_log_m={trained_blocked.block_log_m} block_log_n={trained_blocked.block_log_n}")
+
+    # 2. Construct warm-start DCT-IV.
+    warm_dct4_init = dct4_warm_from_trained_blocked(trained_blocked)
+    print(f"[warmstart] constructed warm-start DCT4Basis: m={warm_dct4_init.m} "
+          f"n={warm_dct4_init.n}, num_tensors={len(warm_dct4_init.tensors)}")
+
+    # 3. Sanity check: forward transforms must agree bit-exactly.
+    rng = np.random.default_rng(0)
+    side_m, side_n = 2 ** cfg["m"], 2 ** cfg["n"]
+    x = rng.standard_normal((side_m, side_n)) + 1j * rng.standard_normal((side_m, side_n))
+    x_jax = jnp.asarray(x, dtype=jnp.complex128)
+    y_blocked = trained_blocked.forward_transform(x_jax)
+    y_warm = warm_dct4_init.forward_transform(x_jax)
+    diff = float(jnp.max(jnp.abs(y_blocked - y_warm)))
+    if diff > 1e-10:
+        print(f"[warmstart] bit-exact check FAILED: max |diff| = {diff:.2e}",
+              file=sys.stderr)
+        return 3
+    print(f"[warmstart] bit-exact check PASSED: max |diff| = {diff:.2e}")
+
+    # 4. Resolve preset + dataset.
+    preset = get_preset(cfg["preset_namespace"], args.preset)
+    preset = replace(preset, epochs=args.epochs, early_stopping_patience=10**9)
+    print(f"[warmstart] preset: epochs={preset.epochs}, batch_size={preset.batch_size}, "
+          f"n_train={preset.n_train}, n_test={preset.n_test}, "
+          f"optimizer={preset.optimizer}")
+
+    train_imgs, test_imgs = load_dataset(
+        cfg["load_dataset"],
+        n_train=preset.n_train,
+        n_test=preset.n_test,
+        seed=preset.seed,
+    )
+    print(f"[warmstart] loaded train={np.asarray(train_imgs).shape if hasattr(train_imgs, 'shape') else len(train_imgs)}, "
+          f"test={np.asarray(test_imgs).shape if hasattr(test_imgs, 'shape') else len(test_imgs)}")
+
+    selected_device = _select_device("auto")
+    print(f"[warmstart] device={selected_device}")
+
+    # 5. Train. The factory must reconstruct the warm-start basis FRESH
+    # because train_one_basis_batched is called twice (warmup + real run)
+    # and we want the same starting point both times.
+    def factory():
+        return dct4_warm_from_trained_blocked(trained_blocked)
+
+    t0 = time.perf_counter()
+    res = train_one_basis_batched(factory, train_imgs, preset, device=selected_device)
+    train_elapsed = time.perf_counter() - t0
+    print(f"[warmstart] training done in {train_elapsed:.1f}s "
+          f"(epochs_completed={res.epochs_completed}, steps={res.steps})")
+
+    # 6. Evaluate at headline keep-ratios.
+    host_basis = jax.tree_util.tree_map(jax.device_get, res.basis)
+    kr_metrics, nan_counts = evaluate_basis_shared(host_basis, test_imgs, preset.keep_ratios)
+    psnr_summary = {kr: m["mean_psnr"] for kr, m in kr_metrics.items()}
+    print("[warmstart] PSNR by keep-ratio: " + ", ".join(
+        f"ρ={kr}: {p:.2f} dB" for kr, p in psnr_summary.items()
+    ))
+
+    # 7. Write cell outputs in the same format the headline pipeline uses.
+    (cell_dir / "loss_history").mkdir(parents=True, exist_ok=True)
+    (cell_dir / "loss_history" / f"{basis_name}_loss.json").write_text(json.dumps({
+        "step_losses": list(res.loss_history),
+        "val_losses": list(res.val_history),
+        "epochs_completed": res.epochs_completed,
+        "steps": res.steps,
+    }))
+
+    host_tensors = [jax.device_get(t) for t in res.basis.tensors]
+    (cell_dir / f"trained_{basis_name}.json").write_text(json.dumps({
+        "type": type(res.basis).__name__,
+        "m": int(res.basis.m),
+        "n": int(res.basis.n),
+        "tensors": [
+            [[float(v.real), float(v.imag)] for v in np.asarray(t).flatten(order="F")]
+            for t in host_tensors
+        ],
+    }, indent=2))
+
+    metrics_payload = {
+        basis_name: {
+            "metrics": kr_metrics,
+            "time": res.time,
+            "_pdft_py": {
+                "warmup_s": res.warmup_s,
+                "device": str(selected_device),
+                "epochs_completed": res.epochs_completed,
+                "steps": res.steps,
+                "n_test": len(test_imgs),
+                "eval_failed_count": nan_counts,
+                "warm_started_from": str(trained_blocked_path),
+                "warmstart_bit_exact_max_diff": diff,
+            },
+        }
+    }
+    (cell_dir / "metrics.json").write_text(json.dumps(metrics_payload, indent=2))
+
+    env = {
+        "jax_version": jax.__version__,
+        "default_backend": jax.default_backend(),
+        "devices": [str(d) for d in jax.devices()],
+        "active_device": str(selected_device),
+        "git_sha": _git_sha(),
+        "git_branch": _git_branch(),
+        "pdft_upstream_ref": pdft.__upstream_ref__,
+        "preset": preset.name,
+        "preset_dataclass": {
+            "epochs": preset.epochs,
+            "n_train": preset.n_train,
+            "n_test": preset.n_test,
+            "optimizer": preset.optimizer,
+            "batch_size": preset.batch_size,
+            "warmup_frac": preset.warmup_frac,
+            "lr_peak": preset.lr_peak,
+            "lr_final": preset.lr_final,
+            "max_grad_norm": preset.max_grad_norm,
+            "validation_split": preset.validation_split,
+            "early_stopping_patience": preset.early_stopping_patience,
+            "seed": preset.seed,
+            "keep_ratios": list(preset.keep_ratios),
+        },
+        "warm_started_from": str(trained_blocked_path),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (cell_dir / "env.json").write_text(json.dumps(env, indent=2))
+
+    print(f"[warmstart] wrote cell -> {cell_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/dct4_topk_sweep.py
+++ b/experiments/dct4_topk_sweep.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""DCT-IV training top-k sweep: does the training compression rate matter?
+
+Real-orthogonal counterpart of ``qft_topk_sweep.py``. Trains analytic-init
+``DCT4Basis(m, n)`` at several *training-k* ratios — the ``MSELoss`` top-k
+truncation count expressed as a fraction of the ``2**(m+n)`` coefficients — and
+evaluates each trained basis at *all* eval keep-ratios. The headline question:
+is each eval compression rate best served by a DCT-IV trained at a matching
+training-k, or does a fixed 10% dominate everywhere?
+
+Training-k ratio ``r`` -> ``k_train = max(1, round(2**(m+n) * r))``
+(``experiment_utils.train_k_for``). Every other hyperparameter matches the
+headline DCT-IV cell — analytic DCT-IV init, the ``generalized`` preset, the
+1008-step budget (``--epochs 112``, early stopping disabled), seed 42 — so the
+``r = 0.10`` run reproduces the headline DCT-IV PSNRs and acts as a built-in
+sanity check.
+
+Standalone driver: does NOT use ``run_experiment``. One cell per training-k at
+``results/training/3_training_topk_dct4/<dataset>/_runs/train_k<pct>/`` (standard
+cell schema: metrics.json, env.json, trained_*.json, loss_history/). An aggregate
+manifest with the full train-k x eval-rho PSNR matrix lands at
+``results/training/3_training_topk_dct4/<dataset>/manifest.json``.
+
+GPU isolation: ``--gpu`` sets ``CUDA_VISIBLE_DEVICES`` BEFORE importing
+pdft_benchmarks (which transitively imports JAX, which preallocates GPU memory).
+
+Usage:
+    python experiments/dct4_topk_sweep.py --gpu 0 --dataset div2k_8q
+    python experiments/dct4_topk_sweep.py --gpu 1 --dataset quickdraw_5q
+    python experiments/dct4_topk_sweep.py --gpu 0 --dataset div2k_8q \\
+        --train-keep-ratios 0.05,0.10,0.15,0.20
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import replace
+from pathlib import Path
+
+
+def _parse_ratios(spec: str) -> list[float]:
+    return [float(x.strip()) for x in spec.split(",") if x.strip()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--gpu", type=int, default=None,
+                        help="GPU index. Sets CUDA_VISIBLE_DEVICES before any pdft/jax import.")
+    parser.add_argument("--dataset", default="div2k_8q",
+                        choices=["div2k_8q", "quickdraw_5q"],
+                        help="Dataset + qubit config: div2k_8q (m=n=8, 256x256) "
+                             "or quickdraw_5q (m=n=5, 32x32).")
+    parser.add_argument("--train-keep-ratios", default="0.05,0.10,0.15,0.20",
+                        help="Comma-separated training-k ratios. One trained "
+                             "DCT-IV per ratio. Default 0.05,0.10,0.15,0.20.")
+    parser.add_argument("--eval-keep-ratios", default="0.05,0.10,0.15,0.20",
+                        help="Comma-separated eval keep-ratios; every trained "
+                             "DCT-IV is evaluated at all of them. Default matches "
+                             "the headline eval grid.")
+    parser.add_argument("--preset", default="generalized",
+                        choices=["smoke", "moderate", "generalized"])
+    parser.add_argument("--epochs", type=int, default=112,
+                        help="Epoch budget per training-k (default 112 = 1008 "
+                             "steps, the headline budget). Early stopping disabled.")
+    parser.add_argument("--out-base", default=None,
+                        help="Parent for per-ratio cells. Default "
+                             "results/training/3_training_topk_dct4/<dataset>/_runs.")
+    parser.add_argument("--force", action="store_true",
+                        help="Retrain every ratio even if its cell already exists; "
+                             "otherwise resume by reading existing metrics.json.")
+    args = parser.parse_args()
+
+    if args.gpu is not None:
+        # Pin by nvidia-smi index. CUDA's default device order is fastest-first,
+        # which scrambles indices on mixed-GPU hosts, so a bare
+        # CUDA_VISIBLE_DEVICES=N can land on a different physical GPU than
+        # nvidia-smi's GPU N. PCI_BUS_ID makes --gpu N select nvidia-smi's GPU N.
+        os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+
+    # IMPORTANT: imports after env var so JAX picks up the isolated device.
+    import jax
+    import pdft
+    import pdft.io  # noqa: F401 — needed by evaluate_basis_shared
+    from pdft_benchmarks.datasets import load_div2k, load_quickdraw
+    from pdft_benchmarks.evaluation import evaluate_basis_shared
+    from pdft_benchmarks.experiment_utils import git_sha, serialize_tensors, train_k_for
+    from pdft_benchmarks.presets import get_preset
+
+    exp = "dct4_topk_sweep"
+    train_ratios = _parse_ratios(args.train_keep_ratios)
+    eval_ratios = tuple(_parse_ratios(args.eval_keep_ratios))
+
+    # GPU fail-fast: when --gpu N was passed, refuse to silently run on CPU
+    # (CLAUDE.md notes NVML init failures can cause this).
+    devices = jax.devices()
+    chosen = devices[0]
+    print(f"[{exp}] JAX devices: {devices}")
+    print(f"[{exp}] chosen device: {chosen} (platform={chosen.platform!r})")
+    if args.gpu is not None and chosen.platform not in ("gpu", "cuda"):
+        print(
+            f"[{exp}] FATAL: --gpu {args.gpu} requested but JAX sees only "
+            f"platform={chosen.platform!r} (NVML init failure?). Aborting to "
+            f"avoid a silent CPU run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    preset = get_preset(args.dataset, args.preset)
+    preset = replace(preset, epochs=args.epochs, early_stopping_patience=10**9)
+
+    DATASET_CFG = {
+        "div2k_8q":     (8, load_div2k, "size"),
+        "quickdraw_5q": (5, load_quickdraw, "img_size"),
+    }
+    m_qubits, dataset_loader, size_kw = DATASET_CFG[args.dataset]
+    m = n = m_qubits
+    train_imgs_np, test_imgs_np = dataset_loader(
+        n_train=preset.n_train, n_test=preset.n_test,
+        seed=preset.seed, **{size_kw: 2 ** m},
+    )
+    print(f"[{exp}] dataset={args.dataset}, m=n={m}, epochs={preset.epochs}, "
+          f"seed={preset.seed}, {len(train_imgs_np)} train / "
+          f"{len(test_imgs_np)} test images")
+    print(f"[{exp}] train-k ratios: {train_ratios}  ->  k = "
+          f"{[train_k_for(m, n, r) for r in train_ratios]}")
+    print(f"[{exp}] eval keep-ratios: {list(eval_ratios)}")
+
+    out_base = Path(args.out_base) if args.out_base else \
+        Path(f"results/training/3_training_topk_dct4/{args.dataset}/_runs")
+    out_base.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict] = []
+    for r in train_ratios:
+        pct = round(r * 100)
+        cell_tag = f"train_k{pct:02d}"
+        basis_name = f"dct4_topk{pct:02d}"
+        out_dir = out_base / cell_tag
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "loss_history").mkdir(parents=True, exist_ok=True)
+        k_train = train_k_for(m, n, r)
+
+        metrics_path = out_dir / "metrics.json"
+        trained_path = out_dir / f"trained_{basis_name}.json"
+
+        if metrics_path.exists() and trained_path.exists() and not args.force:
+            # Resume: reuse the existing durable cell.
+            cell = json.loads(metrics_path.read_text())[basis_name]
+            psnr = {er: float(cell["metrics"][er]["mean_psnr"]) for er in cell["metrics"]}
+            elapsed = float(cell["time"])
+            steps = int(cell["_pdft_py"]["steps"])
+            print(f"\n[{exp}] === train-k {r:.2f} (k={k_train}): RESUMED from "
+                  f"existing cell ===")
+        else:
+            # Train analytic-init DCT-IV at this training-k; everything else fixed.
+            basis = pdft.DCT4Basis(m=m, n=n)
+            print(f"\n[{exp}] === train-k {r:.2f} (k={k_train}, {len(basis.tensors)} "
+                  f"gates) -> {out_dir} ===")
+            t0 = time.perf_counter()
+            result = pdft.train_basis_batched(
+                basis,
+                dataset=train_imgs_np,
+                loss=pdft.MSELoss(k=k_train),
+                epochs=preset.epochs,
+                batch_size=preset.batch_size,
+                optimizer=preset.optimizer,
+                validation_split=preset.validation_split,
+                early_stopping_patience=preset.early_stopping_patience,
+                warmup_frac=preset.warmup_frac,
+                lr_peak=preset.lr_peak,
+                lr_final=preset.lr_final,
+                max_grad_norm=preset.max_grad_norm,
+                shuffle=True, seed=preset.seed,
+                val_every_k_epochs=preset.val_every_k_epochs,
+            )
+            elapsed = time.perf_counter() - t0
+            steps = int(result.steps)
+            epochs_completed = int(result.epochs_completed)
+            print(f"[{exp}]   trained in {elapsed:.1f}s, steps={steps}, "
+                  f"epochs={epochs_completed}")
+
+            eval_metrics, _ = evaluate_basis_shared(
+                result.basis, test_imgs_np, keep_ratios=eval_ratios,
+            )
+            psnr = {er: float(eval_metrics[er]["mean_psnr"]) for er in eval_metrics}
+            print(f"[{exp}]   PSNR by eval-rho: " + ", ".join(
+                f"{er}={p:.3f}" for er, p in psnr.items()))
+
+            # Persist trained tensors first (durable checkpoint), then JSON.
+            trained_path.write_text(json.dumps({
+                "basis": basis_name,
+                "train_ratio": r,
+                "train_k": int(k_train),
+                "m": int(result.basis.m), "n": int(result.basis.n),
+                "tensors": serialize_tensors(result.basis.tensors),
+            }, indent=2))
+            metrics_path.write_text(json.dumps({
+                basis_name: {
+                    "metrics": eval_metrics,
+                    "time": elapsed,
+                    "_pdft_py": {
+                        "train_ratio": r,
+                        "train_k": int(k_train),
+                        "steps": steps,
+                        "epochs_completed": epochs_completed,
+                        "device": str(jax.devices()[0]),
+                        "n_test": int(len(test_imgs_np)),
+                    },
+                }
+            }, indent=2))
+            (out_dir / "loss_history" / f"{basis_name}_loss.json").write_text(json.dumps({
+                "step_losses": [float(x) for x in result.loss_history],
+                "val_losses": [float(x) for x in result.val_history],
+                "epochs_completed": epochs_completed,
+                "steps": steps,
+            }, indent=2))
+            (out_dir / "env.json").write_text(json.dumps({
+                "experiment": exp,
+                "dataset": args.dataset,
+                "train_ratio": r,
+                "train_k": int(k_train),
+                "epochs_used": epochs_completed,
+                "steps_used": steps,
+                "preset_name": args.preset,
+                "preset_epochs": int(args.epochs),
+                "device": str(jax.devices()[0]),
+                "git_sha": git_sha(short=False),
+            }, indent=2))
+
+        rows.append({
+            "train_ratio": r,
+            "train_k": int(k_train),
+            "cell": cell_tag,
+            "psnr": psnr,
+            "steps": int(steps),
+            "elapsed_seconds": float(elapsed),
+        })
+
+    manifest_path = out_base.parent / "manifest.json"
+    manifest_path.write_text(json.dumps({
+        "experiment": exp,
+        "dataset": args.dataset,
+        "m": m, "n": n,
+        "train_keep_ratios": train_ratios,
+        "eval_keep_ratios": list(eval_ratios),
+        "epochs": int(args.epochs),
+        "rows": rows,
+        "git_sha": git_sha(short=False),
+    }, indent=2))
+
+    # Summary: train-k (rows) x eval-rho (cols) PSNR matrix.
+    eval_keys = [k for k in rows[0]["psnr"]] if rows else []
+    print(f"\n[{exp}] sweep complete. Manifest: {manifest_path}")
+    print(f"[{exp}] PSNR (dB) — rows: train-k, cols: eval-rho")
+    print("  train-k \\ rho   " + "  ".join(f"{k:>7s}" for k in eval_keys))
+    for row in rows:
+        cells = "  ".join(f"{row['psnr'][k]:7.3f}" for k in eval_keys)
+        print(f"  k={row['train_ratio']:.2f} (n={row['train_k']:>5d})  {cells}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/div2k_8q_pca_vs_block_dct.py
+++ b/experiments/div2k_8q_pca_vs_block_dct.py
@@ -43,8 +43,9 @@ import sys
 DEFAULT_BASES = ("qft", "entangled_qft", "tebd", "mera",
                  "blocked_8", "rich_8", "real_rich_8")
 # Ablation variants — selectable via --bases but not in the default
-# headline grid.
-EXTRA_BASES = ("qft_identity",)
+# headline grid. dct4_8 (BlockedBasis(DCT4(3,3), 5, 5)) is the trained-blocked
+# input that experiments/dct4_structure_inclusion.py warm-starts from.
+EXTRA_BASES = ("qft_identity", "dct4_8")
 ALL_BASES = DEFAULT_BASES + EXTRA_BASES
 BASELINES = ("fft", "dct", "block_fft_8", "block_dct_8", "pca", "block_pca_8",
              "dct_rank", "block_dct_8_rank", "pca_rank", "block_pca_8_rank",

--- a/experiments/qft_progressive.py
+++ b/experiments/qft_progressive.py
@@ -1,24 +1,27 @@
 #!/usr/bin/env python3
 """Drive the 8-stage progressive block-size sweep on DIV2K-8q.
 
-Supports six circuit families via --family: `qft` (default), `rich`,
-`real_rich`, `tebd`, `entangled_qft`, `mera`. Every family supports both
+Supports seven circuit families via --family: `qft` (default), `rich`,
+`real_rich`, `tebd`, `entangled_qft`, `mera`, `dct4`. Every family supports both
 `--init identity` and `--init random`, and three datasets via --dataset:
 div2k_8q / tuberlin_8q (m=n=8) and quickdraw_5q (m=n=5). The curriculum is
 identical across families; only the per-stage inner basis and its valid k range
-change: `qft`/`rich`/`real_rich` run k=1..m, `tebd`/`entangled_qft` run k=2..m,
-and `mera` runs only k a power of 2 in [2, m].
+change: `qft`/`rich`/`real_rich`/`dct4` run k=1..m, `tebd`/`entangled_qft` run
+k=2..m, and `mera` runs only k a power of 2 in [2, m].
 
 For each stage k, train INDEPENDENTLY from a per-family init:
   - basis = BlockedBasis(<family>(k, k), m-k, m-k)  for k < m
           = bare <family>(m, m)                     for k = m
-  - inner init (--init identity, the default, for qft/rich/real_rich):
+  - inner init (--init identity, the default, for qft/rich/real_rich/dct4):
         qft       : H -> I_2, CP -> phase 0
         rich      : H -> I_2, U4 -> I_4 (complex U(2)/U(4) manifolds)
         real_rich : H -> I_2, U4 -> I_4 (real SO(2)/SO(4) manifolds)
+        dct4      : H/R_y -> I_2, U4 -> I_4, Delta CP -> phase 0 (real-orthogonal)
     inner init (--init random):
         rich      : Haar-random complex U(2)/U(4) gates, seeded by --seed
         real_rich : Haar-random real SO(2)/SO(4) gates, seeded by --seed
+        dct4      : Haar real SO(2)/SO(4) gates, Delta CP at its real sign,
+                    seeded by --seed
         tebd      : native seeded random brick-wall (tebd has no identity
                     init; it REQUIRES --init random)
   - train under the headline preset for --epochs-per-stage epochs
@@ -122,7 +125,7 @@ def main() -> int:
                         help="GPU index. Sets CUDA_VISIBLE_DEVICES before any pdft/jax import.")
     parser.add_argument("--family", type=str, default="qft",
                         choices=["qft", "rich", "real_rich", "tebd",
-                                 "entangled_qft", "mera"],
+                                 "entangled_qft", "mera", "dct4"],
                         help="Circuit family for the per-stage inner basis. "
                              "Default qft. All families support --init "
                              "{identity,random}. mera only trains at k in "
@@ -175,6 +178,7 @@ def main() -> int:
         "tebd": pdft.TEBDBasis,
         "entangled_qft": pdft.EntangledQFTBasis,
         "mera": pdft.MERABasis,
+        "dct4": pdft.DCT4Basis,
     }[family]
 
     # Per-stage inner-basis builder, dispatched by (family, init) via the

--- a/experiments/seed98_full_train.py
+++ b/experiments/seed98_full_train.py
@@ -15,9 +15,12 @@ to the paper, so the only thing the seed moves is the trained operator.
 
 Basis keys (this driver's vocabulary):
     qft, entangled_qft, tebd, mera   — bare full-image families
+    dct4                             — bare full-image DCT-IV (real-orthogonal)
     rich_full                        — bare full-image RichBasis (U(4) gates)
     rich_8                           — RichBasis wrapped into fixed 8×8 blocks
                                        (inner 3-qubit RichBasis, seed-98 init)
+    dct4_b3                          — DCT-IV wrapped into fixed 8×8 blocks
+                                       (inner 3-qubit DCT-IV, seed-98 init)
 
 MERA is unavailable on QuickDraw (m+n=10 is not a power of two); pass a basis
 list that omits it there.
@@ -64,8 +67,8 @@ def _atomic_write_json(path: Path, obj) -> None:
     os.replace(tmp, path)
 
 
-BARE_FAMILIES = ("qft", "entangled_qft", "tebd", "mera")
-BLOCK_FAMILIES = ("qft", "entangled_qft", "tebd", "mera", "rich")
+BARE_FAMILIES = ("qft", "entangled_qft", "tebd", "mera", "dct4")
+BLOCK_FAMILIES = ("qft", "entangled_qft", "tebd", "mera", "rich", "dct4")
 
 
 def _is_pow2(x: int) -> bool:
@@ -121,9 +124,9 @@ def main() -> int:
                     help="GPU index; sets CUDA_VISIBLE_DEVICES before JAX import.")
     ap.add_argument("--dataset", required=True, choices=list(DATASET_CFG))
     ap.add_argument("--bases", required=True,
-                    help="Comma-separated keys: qft|entangled_qft|tebd|mera|"
+                    help="Comma-separated keys: qft|entangled_qft|tebd|mera|dct4|"
                          "rich_full, or block variants <family>_b<innerq> "
-                         "(e.g. qft_b2=4x4, rich_b3=8x8, mera_b4=16x16).")
+                         "(e.g. qft_b2=4x4, rich_b3=8x8, dct4_b3=8x8, mera_b4=16x16).")
     ap.add_argument("--seed", type=int, default=98,
                     help="Init + training-RNG seed (test set stays seed-42).")
     ap.add_argument("--epochs", type=int, default=112,

--- a/src/pdft_benchmarks/bases.py
+++ b/src/pdft_benchmarks/bases.py
@@ -613,6 +613,167 @@ def _qft_random_basis(m: int, n: int, seed: int):
                          code=base.code, inv_code=base.inv_code)
 
 
+# ---------------------------------------------------------------------------
+# DCT-IV identity / random / inner-outer / warm-start helpers.
+#
+# DCT4Basis stores EVERY gate (R_y / branch-H / CR_y / mirror-Q CNOT / Delta)
+# as a learnable leaf, sorted Hadamard-first BY VALUE (compile_circuit's
+# _hadamard_first_perm). Unlike the QFT helpers we cannot key the storage sort
+# on ``kind != "H"`` — the R_y rotations are kind "H" but are NOT Hadamard-
+# valued — so these helpers read the storage order straight from the builder
+# (sorted_gate_program / _hadamard_first_perm) and then map by gate KIND.
+# ---------------------------------------------------------------------------
+
+
+def dct4_identity_basis(m: int, n: int) -> "pdft.DCT4Basis":
+    """Construct a ``DCT4Basis(m, n)`` whose operator is the identity.
+
+    Every gate is pinned to the identity element of its slot, keyed by gate
+    kind: H / R_y -> I_2, U4 (CR_y, mirror-Q) -> I_4, CP (Delta) -> phase 0.
+    With all gates trivial the circuit is a no-op, so ``forward(x) == x``.
+    """
+    import jax.numpy as jnp
+    from pdft.bases.circuit.dct4 import _dct4_gates_1d
+    from pdft.circuit.builder import controlled_phase_diag, sorted_gate_program
+
+    gates = _dct4_gates_1d(m, offset=0) + _dct4_gates_1d(n, offset=m)
+    ident = {
+        "H": jnp.eye(2, dtype=jnp.complex128),
+        "U4": jnp.eye(4, dtype=jnp.complex128).reshape(2, 2, 2, 2),
+        "CP": controlled_phase_diag(0.0),
+    }
+    new_tensors = [ident[kind] for kind, _q in sorted_gate_program(gates)]
+    base = pdft.DCT4Basis(m=m, n=n)
+    return pdft.DCT4Basis(m=m, n=n, tensors=new_tensors,
+                          code=base.code, inv_code=base.inv_code)
+
+
+def _dct4_random_basis(m: int, n: int, seed: int) -> "pdft.DCT4Basis":
+    """Haar-random real-orthogonal init on the DCT-IV topology.
+
+    H / R_y slots -> Haar SO(2), U4 slots (CR_y, mirror-Q) -> Haar SO(4); the
+    Delta CP slot keeps its real sign ``controlled_phase_diag(pi)`` (its only
+    real-orthogonal value — a real objective leaves it stationary anyway).
+    Seeded, reproducible; mirrors ``_circuit_random_basis`` for RealRichBasis.
+    """
+    import jax.numpy as jnp
+    import numpy as np
+    from pdft.bases.circuit.dct4 import _dct4_gates_1d
+    from pdft.circuit.builder import controlled_phase_diag, sorted_gate_program
+
+    gates = _dct4_gates_1d(m, offset=0) + _dct4_gates_1d(n, offset=m)
+    rng = np.random.default_rng(seed)
+    cp_pi = jnp.asarray(controlled_phase_diag(float(np.pi)), dtype=jnp.complex128)
+    new_tensors = []
+    for kind, _q in sorted_gate_program(gates):
+        if kind == "H":
+            new_tensors.append(jnp.asarray(_haar_special_orthogonal(2, rng), dtype=jnp.complex128))
+        elif kind == "U4":
+            u = _haar_special_orthogonal(4, rng).reshape(2, 2, 2, 2)
+            new_tensors.append(jnp.asarray(u, dtype=jnp.complex128))
+        elif kind == "CP":
+            new_tensors.append(cp_pi)
+        else:
+            raise AssertionError(f"unexpected DCT-IV gate kind {kind!r}")
+    base = pdft.DCT4Basis(m=m, n=n)
+    return pdft.DCT4Basis(m=m, n=n, tensors=new_tensors,
+                          code=base.code, inv_code=base.inv_code)
+
+
+def dct4_inner_outer_indices(
+    m: int, n: int, inner_m: int, inner_n: int,
+) -> tuple[list[int], list[int]]:
+    """Return (inner_indices, outer_indices) into ``DCT4Basis(m, n).tensors``.
+
+    A gate is "inner" iff every qubit it touches lies in the inner block:
+    axis-1 builder qubits {1..inner_m}, axis-2 {m+1..m+inner_n} — the LOW
+    qubits BlockedBasis tiles the inner DCT-IV over. Indices are into the
+    value-sorted (Hadamard-first) storage order DCT4Basis uses.
+    """
+    from pdft.bases.circuit.dct4 import _dct4_gates_1d
+    from pdft.circuit.builder import sorted_gate_program
+
+    if not (0 <= inner_m <= m and 0 <= inner_n <= n):
+        raise ValueError(
+            f"dct4_inner_outer_indices: invalid inner (inner_m={inner_m}, "
+            f"inner_n={inner_n}) for m={m}, n={n}"
+        )
+    gates = _dct4_gates_1d(m, offset=0) + _dct4_gates_1d(n, offset=m)
+
+    def _is_inner_q(q: int) -> bool:
+        return q <= inner_m if q <= m else (q - m) <= inner_n
+
+    inner: list[int] = []
+    outer: list[int] = []
+    for i, (_kind, qubits) in enumerate(sorted_gate_program(gates)):
+        (inner if all(_is_inner_q(q) for q in qubits) else outer).append(i)
+    return inner, outer
+
+
+def dct4_warm_from_trained_blocked(trained_blocked: "pdft.BlockedBasis") -> "pdft.DCT4Basis":
+    """Embed a trained ``BlockedBasis(DCT4Basis(m_i, n_i), block_log_m, block_log_n)``
+    into a full ``DCT4Basis(m, n)`` whose initial operator equals the trained
+    blocked one bit-exactly.
+
+    Inner-block gates (all qubits in the inner block) take the TRAINED inner
+    tensor; every outer gate is pinned to its kind's identity (H -> I_2,
+    U4 -> I_4, CP -> phase 0), which collapses the outer recursion levels to a
+    no-op so the full operator reduces to the tiled inner = the blocked basis.
+    All m+n axis parameters stay trainable for the subsequent re-train.
+    """
+    import jax.numpy as jnp
+    from pdft.bases.circuit.dct4 import _dct4_gates_1d
+    from pdft.circuit.builder import _hadamard_first_perm, controlled_phase_diag
+
+    inner = trained_blocked.inner
+    if not isinstance(inner, pdft.DCT4Basis):
+        raise TypeError(
+            f"dct4_warm_from_trained_blocked: inner must be DCT4Basis, "
+            f"got {type(inner).__name__}"
+        )
+    m_i, n_i = inner.m, inner.n
+    m_o = m_i + trained_blocked.block_log_m
+    n_o = n_i + trained_blocked.block_log_n
+
+    # The full DCT-IV's inner-level gates (touching only inner qubits) form a
+    # contiguous emission block equal, gate-for-gate, to the standalone inner
+    # DCT-IV's emission — so pair them POSITIONALLY. (A (kind, qubits) dict
+    # would collide: each level emits two identical mirror-Q CNOTs and an R_y +
+    # branch-H on the same qubit.) inner.tensors is value-sorted storage order,
+    # so first invert that back to emission order.
+    inner_gates = _dct4_gates_1d(m_i, offset=0) + _dct4_gates_1d(n_i, offset=m_i)
+    inner_perm = _hadamard_first_perm([g["tensor"] for g in inner_gates])
+    emit_to_storage = [0] * len(inner_gates)
+    for storage_pos, emit_idx in enumerate(inner_perm):
+        emit_to_storage[emit_idx] = storage_pos
+    inner_emit = [inner.tensors[emit_to_storage[j]] for j in range(len(inner_gates))]
+
+    outer_identity = {
+        "H": jnp.eye(2, dtype=jnp.complex128),
+        "U4": jnp.eye(4, dtype=jnp.complex128).reshape(2, 2, 2, 2),
+        "CP": controlled_phase_diag(0.0),
+    }
+
+    def _is_inner_q(q: int) -> bool:
+        return q <= m_i if q <= m_o else (q - m_o) <= n_i
+
+    outer_gates = _dct4_gates_1d(m_o, offset=0) + _dct4_gates_1d(n_o, offset=m_o)
+    temporal, ip = [], 0
+    for g in outer_gates:
+        if all(_is_inner_q(q) for q in g["qubits"]):
+            temporal.append(inner_emit[ip])
+            ip += 1
+        else:
+            temporal.append(outer_identity[g["kind"]])
+    if ip != len(inner_emit):
+        raise AssertionError(
+            f"consumed {ip} inner gates != {len(inner_emit)} trained inner tensors"
+        )
+    perm = _hadamard_first_perm([g["tensor"] for g in outer_gates])
+    sorted_tensors = [jnp.asarray(temporal[i], dtype=jnp.complex128) for i in perm]
+    return pdft.DCT4Basis(m=m_o, n=n_o, tensors=sorted_tensors)
+
+
 _FAMILY_CLASS = {
     "qft": pdft.QFTBasis,
     "rich": pdft.RichBasis,
@@ -620,6 +781,7 @@ _FAMILY_CLASS = {
     "tebd": pdft.TEBDBasis,
     "entangled_qft": pdft.EntangledQFTBasis,
     "mera": pdft.MERABasis,
+    "dct4": pdft.DCT4Basis,
 }
 
 
@@ -627,8 +789,11 @@ def family_identity_basis(family: str, m: int, n: int):
     """Identity-operator init for a circuit family (bare, unblocked).
 
     Rich/RealRich use shape-based identity (U(2)/U(4)); QFT/TEBD/EntangledQFT/
-    MERA use value-based identity (Hadamard -> I_2, controlled-phase -> phase 0).
+    MERA use value-based identity (Hadamard -> I_2, controlled-phase -> phase 0);
+    DCT-IV keys by gate kind (H/R_y -> I_2, U4 -> I_4, Delta CP -> phase 0).
     """
+    if family == "dct4":
+        return dct4_identity_basis(m, n)
     cls = _FAMILY_CLASS[family]
     if family in ("rich", "real_rich"):
         return _circuit_identity_basis(cls, m, n)
@@ -639,9 +804,12 @@ def family_random_basis(family: str, m: int, n: int, seed: int):
     """Random (Haar / native-seed) init for a circuit family (bare, unblocked).
 
     QFT -> Haar U(2) on H slots + uniform phase on CP slots; Rich/RealRich ->
-    Haar U/SO on every gate; TEBD/EntangledQFT/MERA -> the constructor's own
+    Haar U/SO on every gate; DCT-IV -> Haar SO(2)/SO(4) on H/U4 slots, Delta CP
+    kept at its real sign; TEBD/EntangledQFT/MERA -> the constructor's own
     seeded random init. Seeded; reproduces the family×init sweep's random cells.
     """
+    if family == "dct4":
+        return _dct4_random_basis(m, n, seed)
     cls = _FAMILY_CLASS[family]
     if family in ("tebd", "entangled_qft", "mera"):
         return cls(m=m, n=n, seed=seed)
@@ -653,4 +821,6 @@ def family_random_basis(family: str, m: int, n: int, seed: int):
 __all__ = ["BASIS_FACTORIES", "BasisFactory", "qft_identity_basis",
            "identity_basis_for", "qft_warm_from_smaller_qft",
            "qft_inner_outer_indices",
+           "dct4_identity_basis", "dct4_inner_outer_indices",
+           "dct4_warm_from_trained_blocked",
            "family_identity_basis", "family_random_basis"]

--- a/src/pdft_benchmarks/unfreeze.py
+++ b/src/pdft_benchmarks/unfreeze.py
@@ -49,6 +49,48 @@ def qft_unfreeze_orders(m: int, n: int) -> dict[str, list[int]]:
     return {"bg": bg, "lr": lr, "rl": rl}
 
 
+def dct4_unfreeze_orders(m: int, n: int) -> dict[str, list[int]]:
+    """Three unfreeze orderings as lists of indices into ``DCT4Basis(m, n).tensors``.
+
+    DCT4Basis stores gates Hadamard-first BY VALUE (only the branch-H merges
+    equal the Hadamard; the R_y rotations are kind "H" but are not), so we read
+    the storage permutation from the builder's value-based ``_hadamard_first_perm``
+    instead of the QFT kind-based key.
+
+      - lr: emission order
+      - rl: reverse emission order
+      - bg: block growth — group by stage (the largest within-axis builder qubit
+        a gate touches; = sub-block size, since the DCT-IV on qubits 1..k IS the
+        size-2^k block), row axis before col, emission order within. Unfreezing
+        stages 1..k completes the blocked DCT-IV(k, k).
+    """
+    from pdft.bases.circuit.dct4 import _dct4_gates_1d
+    from pdft.circuit.builder import _hadamard_first_perm
+
+    gates = _dct4_gates_1d(m, offset=0) + _dct4_gates_1d(n, offset=m)
+    G = len(gates)
+    perm = _hadamard_first_perm([g["tensor"] for g in gates])
+    emission_to_storage = [0] * G
+    for storage_pos, emission_idx in enumerate(perm):
+        emission_to_storage[emission_idx] = storage_pos
+
+    def axis_of(q: int) -> int:
+        return 0 if q <= m else 1
+
+    def within(q: int) -> int:
+        return q if q <= m else q - m
+
+    keys = []  # (stage, axis, emission_idx)
+    for e, g in enumerate(gates):
+        within_qs = [within(q) for q in g["qubits"]]
+        keys.append((max(within_qs), axis_of(g["qubits"][0]), e))
+
+    lr = [emission_to_storage[e] for e in range(G)]
+    rl = list(reversed(lr))
+    bg = [emission_to_storage[k[2]] for k in sorted(keys)]
+    return {"bg": bg, "lr": lr, "rl": rl}
+
+
 def _plateau_reason(grad_norm, loss, loss_prev, *, step, min_steps, grad_tol, loss_tol):
     """Return the trigger reason ("grad_norm" | "loss_delta") or None.
 

--- a/tests/test_dct4_suite.py
+++ b/tests/test_dct4_suite.py
@@ -1,0 +1,97 @@
+"""DCT-IV experiment-suite infra: identity/random init, unfreeze orders,
+inner/outer partition, and the load-bearing warm-start bit-exactness.
+
+These guard the helpers the dct4_* drivers stand on. The warm-start check is the
+one that can silently regress: DCT-IV emits two identical mirror-Q CNOTs and an
+R_y + branch-H on the same qubit per level, so the inner-level gates must be
+paired POSITIONALLY (a (kind, qubits) dict would collide). If that pairing
+breaks, the warm operator drifts toward identity instead of staying bit-exact.
+"""
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pdft
+
+from pdft_benchmarks.bases import (
+    _dct4_random_basis,
+    dct4_identity_basis,
+    dct4_inner_outer_indices,
+    dct4_warm_from_trained_blocked,
+    family_random_basis,
+)
+from pdft_benchmarks.unfreeze import dct4_unfreeze_orders, train_progressive_unfreeze
+
+
+def _rnd_real(shape, seed):
+    return jnp.asarray(np.random.default_rng(seed).standard_normal(shape),
+                       dtype=jnp.complex128)
+
+
+def test_dct4_identity_basis_is_identity_op():
+    b = dct4_identity_basis(3, 3)
+    x = _rnd_real((8, 8), 1)
+    err = float(jnp.max(jnp.abs(b.forward_transform(x) - x)))
+    assert err < 1e-12, f"identity basis not a no-op: max|fwd(x)-x|={err:.2e}"
+
+
+def test_dct4_random_basis_is_real_and_orthogonal():
+    b = family_random_basis("dct4", 3, 3, 5)
+    imag = max(float(jnp.max(jnp.abs(jnp.imag(t)))) for t in b.tensors)
+    assert imag < 1e-12, f"random init not real: max|imag|={imag:.2e}"
+    x = _rnd_real((8, 8), 2)
+    rt = float(jnp.max(jnp.abs(b.inverse_transform(b.forward_transform(x)) - x)))
+    assert rt < 1e-10, f"random init not orthogonal: round-trip err={rt:.2e}"
+
+
+def test_dct4_unfreeze_orders_are_permutations():
+    for m in (2, 3, 4):
+        G = len(pdft.DCT4Basis(m=m, n=m).tensors)
+        orders = dct4_unfreeze_orders(m, m)
+        assert set(orders.keys()) == {"bg", "lr", "rl"}
+        for name, seq in orders.items():
+            assert sorted(seq) == list(range(G)), f"{name} not a permutation at m={m}"
+        assert orders["rl"] == list(reversed(orders["lr"]))
+
+
+def test_dct4_bg_prefix_completes_inner_blocks():
+    # Unfreezing block-growth stages 1..k must complete the blocked DCT-IV(k, k):
+    # the bg prefix of length |inner(k,k)| is exactly the inner-block index set.
+    orders = dct4_unfreeze_orders(4, 4)
+    for k in (1, 2, 3):
+        inner_k, _ = dct4_inner_outer_indices(4, 4, k, k)
+        assert set(orders["bg"][:len(inner_k)]) == set(inner_k), \
+            f"bg prefix != inner({k},{k})"
+
+
+def test_dct4_inner_outer_partition():
+    # Complete & disjoint, and the m=n=8 inner-3 partition is 34 inner / 180 outer.
+    inner, outer = dct4_inner_outer_indices(8, 8, 3, 3)
+    G = len(pdft.DCT4Basis(m=8, n=8).tensors)
+    assert sorted(inner + outer) == list(range(G))
+    assert not (set(inner) & set(outer))
+    assert len(inner) == 34 and len(outer) == 180, \
+        f"{len(inner)} inner + {len(outer)} outer (expected 34 + 180 = {G})"
+
+
+def test_dct4_warm_from_trained_blocked_is_bit_exact():
+    # THE critical check: a full DCT4Basis warm-started from a trained
+    # BlockedBasis(DCT4(2,2), 2, 2) must reproduce the blocked operator exactly.
+    inner = _dct4_random_basis(2, 2, 7)
+    blocked = pdft.BlockedBasis(inner=inner, block_log_m=2, block_log_n=2)
+    warm = dct4_warm_from_trained_blocked(blocked)
+    assert warm.m == 4 and warm.n == 4
+    x = _rnd_real((16, 16), 3)
+    err = float(jnp.max(jnp.abs(blocked.forward_transform(x) - warm.forward_transform(x))))
+    assert err < 1e-10, f"warm-start not bit-exact vs blocked: max|diff|={err:.2e}"
+
+
+def test_dct4_progressive_unfreeze_runs():
+    # Smoke: the unfreeze loop runs end-to-end on a DCT4Basis and returns one.
+    ds = [np.asarray(_rnd_real((8, 8), s)) for s in range(4)]
+    res = train_progressive_unfreeze(
+        family_random_basis("dct4", 3, 3, 1), ds,
+        unfreeze_order=dct4_unfreeze_orders(3, 3)["bg"][:2], lr=0.01,
+        max_steps_per_stage=3, loss=pdft.MSELoss(k=10), min_steps_per_stage=1)
+    assert isinstance(res.basis, pdft.DCT4Basis)
+    assert len(res.stages) == 2


### PR DESCRIPTION
Faithfully mirrors the QFT training studies for the real-orthogonal **DCT-IV** ansatz. Every DCT-IV gate is treated as a learnable leaf on its auto-selected Riemannian manifold (R_y / branch-H on O(2), CR_y / mirror-Q on O(4), the Delta sign on the phase manifold) — exactly like QFT relaxes within U — so the same protocols transfer one-for-one.

## Infra (`src/pdft_benchmarks/`)
- **`bases.py`** — `dct4_identity_basis`, `_dct4_random_basis` (Haar SO(2)/SO(4), Delta CP kept at its real sign), `dct4_inner_outer_indices`, `dct4_warm_from_trained_blocked`, plus `dct4` wiring into `_FAMILY_CLASS` / `family_identity_basis` / `family_random_basis`.
- **`unfreeze.py`** — `dct4_unfreeze_orders` (bg/lr/rl). Reads the storage sort from the builder's value-based `_hadamard_first_perm`, not the QFT kind-based key: DCT-IV's R_y gates are kind `"H"` but **not** Hadamard-valued.

**Warm-start correctness.** The full circuit's inner-level gates are paired to the standalone inner emission **positionally**, not by `(kind, qubits)`: each DCT-IV level emits two identical mirror-Q CNOTs plus an R_y + branch-H on the same qubit, so a keyed lookup collides. Verified **bit-exact** against the blocked operator (`max|blocked − warm| = 0`).

## Drivers (`experiments/dct4_*.py`), one-for-one with the `qft_*` siblings
| driver | mirrors | needs a pre-trained `dct4_8`? |
|---|---|---|
| `dct4_topk_sweep` | `qft_topk_sweep` | no |
| `dct4_seed_sweep` | `qft_seed_sweep` | no |
| `dct4_freeze_sweep` | `qft_freeze_sweep` | no |
| `dct4_direct_training` | `qft_direct_training unfreeze` | no |
| `dct4_structure_inclusion` | `qft_structure_inclusion` | **yes** (two-step, below) |

The QFT-specific L1 / identity-regularisation modes are intentionally omitted (DCT-IV's CNOT/CR_y/Delta skeleton has no "identity" headline to anchor to).

**Registration:** `dct4` added to `seed98_full_train` (BARE/BLOCK_FAMILIES → `dct4`, `dct4_b3`) and `qft_progressive` (`--family dct4`, `basis_cls`). `dct4_8` (= `BlockedBasis(DCT4(3,3), 5, 5)`) added to the div2k structure entrypoint's opt-in `EXTRA_BASES` — the paper's default headline grid is unchanged.

## Running the suite (div2k_8q)

Four drivers are self-contained — run directly, parallelise across GPUs:

```bash
python experiments/dct4_topk_sweep.py       --gpu 0 --dataset div2k_8q
python experiments/dct4_seed_sweep.py       --gpu 1 --orderings bg,lr,rl --seeds 1-100
python experiments/dct4_freeze_sweep.py     --gpu 2
python experiments/dct4_direct_training.py  --gpu 3 --dataset div2k_8q
```

`dct4_structure_inclusion` is two steps (train the blocked basis, then warm-start from it):

```bash
# 1. produce the trained dct4_8 cell (now selectable via --bases)
python experiments/div2k_8q_pca_vs_block_dct.py --gpu 0 --bases dct4_8 --no-early-stop
#    -> results/structure/div2k_8q_pca_vs_block_dct/by_basis/dct4_8/trained_dct4_8.json

# 2. warm-start the full DCT-IV from it and re-train (reads the path above by default)
python experiments/dct4_structure_inclusion.py --dataset div2k_8q --gpu 0
```

`load_trained_basis` keys the inner topology off the filename stem, so the step-1 cell must stay named `trained_dct4_8.json`.

## Notes
- The four self-contained drivers also support `--dataset quickdraw_5q` directly. `dct4_structure_inclusion --dataset quickdraw` is **not** wired yet — the quickdraw structure entrypoint hardcodes its basis list (no `--bases`); enabling it there would change that run's default grid. Say the word and I'll add a `--bases` opt-in.
- DCT-IV has ~3× the QFT gate count (214 vs 72 tensors at m=n=8 — the CNOT/CR_y skeleton), so the per-gate unfreeze sweeps have ~3× the stages. Faithful to QFT (one stage per gate), just more compute.

## Tests
`tests/test_dct4_suite.py` (7 tests) guards identity-op, real+orthogonal random init, unfreeze permutations + bg-completes-blocks, inner/outer partition (34 + 180), the **warm-start bit-exactness**, and progressive-unfreeze end-to-end. Locally: **7/7 new + 103 existing pass**; the lone failure (`test_qft_progressive_smoke`) is a pre-existing hardcoded remote interpreter path, untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)