### PR TITLE
Paper figure renderers + DCT-IV (relaxed) support

### DIFF
--- a/experiments/div2k_8q_pca_vs_block_dct.py
+++ b/experiments/div2k_8q_pca_vs_block_dct.py
@@ -44,7 +44,7 @@ DEFAULT_BASES = ("qft", "entangled_qft", "tebd", "mera",
                  "blocked_8", "rich_8", "real_rich_8")
 # Ablation variants — selectable via --bases but not in the default
 # headline grid.
-EXTRA_BASES = ("qft_identity",)
+EXTRA_BASES = ("qft_identity", "dct4_ctl")
 ALL_BASES = DEFAULT_BASES + EXTRA_BASES
 BASELINES = ("fft", "dct", "block_fft_8", "block_dct_8", "pca", "block_pca_8",
              "dct_rank", "block_dct_8_rank", "pca_rank", "block_pca_8_rank",

--- a/experiments/quickdraw_pca_vs_block_dct.py
+++ b/experiments/quickdraw_pca_vs_block_dct.py
@@ -27,6 +27,9 @@ from pdft_benchmarks.pipeline import run_experiment
 
 DEFAULT_BASES = ("qft", "entangled_qft", "tebd", "mera",
                  "blocked", "rich", "real_rich")
+# Ablation variants — selectable via --bases but not in the default grid.
+EXTRA_BASES = ("dct4_ctl",)
+ALL_BASES = DEFAULT_BASES + EXTRA_BASES
 
 
 def main():
@@ -45,10 +48,10 @@ def main():
     args = parser.parse_args()
 
     bases = [b.strip() for b in args.bases.split(",") if b.strip()]
-    unknown = [b for b in bases if b not in DEFAULT_BASES]
+    unknown = [b for b in bases if b not in ALL_BASES]
     if unknown:
         raise SystemExit(f"unknown basis name(s): {unknown}; "
-                         f"choices: {sorted(DEFAULT_BASES)}")
+                         f"choices: {sorted(ALL_BASES)}")
 
     preset = apply_preset_overrides(
         args.preset, dataset="quickdraw", tag="quickdraw",

--- a/src/pdft_benchmarks/_loading.py
+++ b/src/pdft_benchmarks/_loading.py
@@ -47,7 +47,6 @@ def load_trained_basis(json_path: Path):
     from pdft_benchmarks.bases import BASIS_FACTORIES
 
     payload = json.loads(Path(json_path).read_text())
-    btype = payload["type"]
     m, n = int(payload["m"]), int(payload["n"])
     raw = payload["tensors"]
 
@@ -56,29 +55,55 @@ def load_trained_basis(json_path: Path):
         "EntangledQFTBasis": "entangled_qft",
         "TEBDBasis":         "tebd",
         "MERABasis":         "mera",
+        "DCT4Basis":         "dct4_ctl",
     }
-    if btype == "BlockedBasis":
-        # blocked / rich / real_rich all serialise as "BlockedBasis";
-        # disambiguate by filename stem (e.g. "trained_real_rich_8" → "real_rich_8").
-        factory_key = Path(json_path).stem.removeprefix("trained_")
-    else:
-        factory_key = _type_to_factory_key[btype]
+    # Full-image Rich variants have no BASIS_FACTORIES entry (the "rich" /
+    # "real_rich" factories are block-wrapped); the loader builds the pdft class
+    # directly. Legacy cells identify these by their run "key".
+    _full_image_classes = {"rich_full": "RichBasis", "real_rich_full": "RealRichBasis"}
 
-    skel = BASIS_FACTORIES[factory_key](m, n, seed=0)
+    btype = payload.get("type")
+    is_blocked = btype == "BlockedBasis"
+    skel = None
+    if btype is not None:
+        if is_blocked:
+            # blocked / rich / real_rich all serialise as "BlockedBasis";
+            # disambiguate by filename stem (e.g. "trained_real_rich_8").
+            factory_key = Path(json_path).stem.removeprefix("trained_")
+        else:
+            factory_key = _type_to_factory_key[btype]
+    elif "key" in payload:
+        key = payload["key"]
+        if key in _full_image_classes:
+            import pdft
+            skel = getattr(pdft, _full_image_classes[key])(m=m, n=n)
+        factory_key = key
+    else:
+        raise ValueError(
+            f"{json_path}: cannot determine basis type ('type'/'key' missing)"
+        )
+
+    if skel is None:
+        skel = BASIS_FACTORIES[factory_key](m, n, seed=0)
+
+    def _decode_one(raw_t, shape):
+        # Two on-disk serialisations of a complex tensor are supported:
+        #   new:  a flat list of [re, im] pairs (reshaped Fortran-order)
+        #   old:  a {"real": [...], "imag": [...]} dict already in tensor shape
+        if isinstance(raw_t, dict):
+            arr = (np.asarray(raw_t["real"], dtype=np.float64)
+                   + 1j * np.asarray(raw_t["imag"], dtype=np.float64))
+            return arr if arr.shape == tuple(shape) else arr.reshape(shape)
+        flat = np.asarray([complex(r, i) for r, i in raw_t], dtype=np.complex128)
+        return flat.reshape(shape, order="F")
 
     def _decode(skel_tensors):
-        out = []
-        for skel_t, raw_t in zip(skel_tensors, raw):
-            flat = np.asarray(
-                [complex(r, i) for r, i in raw_t], dtype=np.complex128
-            )
-            out.append(flat.reshape(skel_t.shape, order="F"))
-        return out
+        return [_decode_one(raw_t, skel_t.shape)
+                for skel_t, raw_t in zip(skel_tensors, raw)]
 
-    if btype == "BlockedBasis":
+    if is_blocked:
         inner = skel.inner
-        new_inner_tensors = _decode(inner.tensors)
-        object.__setattr__(inner, "tensors", new_inner_tensors)
+        object.__setattr__(inner, "tensors", _decode(inner.tensors))
         return skel
 
     new_tensors = _decode(skel.tensors)

--- a/src/pdft_benchmarks/bases.py
+++ b/src/pdft_benchmarks/bases.py
@@ -66,6 +66,10 @@ BASIS_FACTORIES: dict[str, BasisFactory] = {
     "mera":          lambda m, n, seed=0: pdft.MERABasis(m=m, n=n, seed=seed),
     # Learnable cosine basis: exact DCT-IV at init, then relaxed (ancilla-free).
     "dct4":          lambda m, n, seed=0: pdft.DCT4Basis(m=m, n=n),
+    # Exact-init DCT-IV in the O(2)-twiddle "controlled" parametrization — the
+    # "DCT-IV (relaxed)" of the main table. Trained through run_experiment it
+    # logs a val-MSE trajectory comparable to the other full-image bases.
+    "dct4_ctl":      lambda m, n, seed=0: pdft.DCT4Basis(m=m, n=n, parametrization="controlled"),
     # Block topologies (3): default split — inner basis at (m+1)//2.
     # At QuickDraw m=5: inner_m=3 → 8×8 blocks. At DIV2K m=8: inner_m=4 → 16×16 blocks.
     "blocked":       lambda m, n, seed=0: _blocked(m, n, seed, pdft.QFTBasis),

--- a/tools/render_freq_recon_grid.py
+++ b/tools/render_freq_recon_grid.py
@@ -45,6 +45,15 @@ def _load_div2k_source_image(idx: int, *, size: int = 256) -> np.ndarray:
     return np.asarray(img, dtype=np.float64) / 255.0
 
 
+def _load_custom_image(path: str, *, size: int) -> np.ndarray:
+    """Load an arbitrary image file as a grayscale float64 [0,1] array resized
+    to size×size. Used to render on a specific picture (e.g. the exact Quick
+    Draw cat embedded in the Figure 1 banner) rather than a test-split index."""
+    from PIL import Image
+    img = Image.open(path).convert("L").resize((size, size), Image.Resampling.LANCZOS)
+    return np.asarray(img, dtype=np.float64) / 255.0
+
+
 from pdft_benchmarks._loading import load_trained_basis  # noqa: F401  (re-export for callers)
 
 
@@ -72,9 +81,15 @@ def main():
     ap.add_argument("--methods", type=str, default="",
                     help="Comma-separated method names to include "
                          "(e.g. 'fft,dct,qft,block_dct_8,real_rich_8'). "
-                         "Empty → include all available. The block-wrapped-"
-                         "before-global ordering is preserved within the "
-                         "selected subset.")
+                         "Empty → include all available. When given, the "
+                         "columns follow this exact order.")
+    ap.add_argument("--custom-images", type=str, default="",
+                    help="Comma-separated 'path:label' (or just path) image "
+                         "files to render on, resized to the dataset img_size; "
+                         "label becomes the output _img<label> suffix.")
+    ap.add_argument("--by-basis-root", type=str, default="",
+                    help="Override the by_basis directory the trained cells are "
+                         "discovered from (default: the dataset's canonical tree).")
     args = ap.parse_args()
 
     DATASET_CONFIG = {
@@ -130,15 +145,20 @@ def main():
     for src_id in div2k_source_indices:
         images.append(_load_div2k_source_image(src_id, size=cfg["img_size"]))
         image_labels.append(src_id)
+    for spec in [s for s in args.custom_images.split(",") if s.strip()]:
+        path, label = spec.rsplit(":", 1) if ":" in spec else (spec, Path(spec).stem)
+        images.append(_load_custom_image(path, size=cfg["img_size"]))
+        image_labels.append(label)
     if not images:
-        raise ValueError("no images selected; pass --image-indices and/or --div2k-source-indices")
+        raise ValueError("no images selected; pass --image-indices, "
+                         "--div2k-source-indices, and/or --custom-images")
     print(f"[viz] {len(images)} images, labels={image_labels}, ρ={keep_ratios}")
 
     # ---- Load trained bases ----
     # Discover from disk: any <by_basis>/<name>/trained_<name>.json present.
     # This handles both datasets and any future basis names without
     # hardcoding (e.g. blocked vs blocked_8, with/without mera).
-    by_basis_root = Path(cfg["by_basis"])
+    by_basis_root = Path(args.by_basis_root) if args.by_basis_root else Path(cfg["by_basis"])
     trained: dict = {}
     if by_basis_root.is_dir():
         for cell in sorted(by_basis_root.iterdir()):
@@ -203,33 +223,29 @@ def main():
             rec[(i_idx, kr)] = per_method
 
     # ---- Plot — one separate PNG per test image ----
-    # Method ordering: block-wrapped on the left, global on the right.
-    # Use a preferred-order list that includes both legacy (blocked/rich/...) and
-    # new (*_8) trained names; whichever exists in `rec` gets included.
-    block_methods_pref = [
-        # trained block-wrapped (legacy default-split + new fixed-8 variants)
-        "rich", "real_rich", "blocked",
-        "rich_8", "real_rich_8", "blocked_8",
-        # classical 8x8-block baselines
-        "block_dct_8", "block_bd_pca_8", "block_fft_8",
-    ]
-    global_methods_pref = ["qft", "entangled_qft", "tebd", "mera", "bd_pca", "dct", "fft"]
+    # Method ordering. With --methods the columns follow that exact order;
+    # otherwise fall back to block-wrapped-on-the-left, global-on-the-right.
     sample_key = (image_labels[0], keep_ratios[0])
-    block_methods  = [m for m in block_methods_pref  if m in rec[sample_key]]
-    global_methods = [m for m in global_methods_pref if m in rec[sample_key]]
+    available = list(rec[sample_key].keys())
     if args.methods:
-        requested = [m.strip() for m in args.methods.split(",") if m.strip()]
-        available = set(block_methods) | set(global_methods)
-        missing = [m for m in requested if m not in available]
+        methods = [m.strip() for m in args.methods.split(",") if m.strip()]
+        missing = [m for m in methods if m not in available]
         if missing:
             raise ValueError(
                 f"requested methods not available: {missing}; "
                 f"available: {sorted(available)}"
             )
-        requested_set = set(requested)
-        block_methods  = [m for m in block_methods  if m in requested_set]
-        global_methods = [m for m in global_methods if m in requested_set]
-    methods = block_methods + global_methods
+    else:
+        block_methods_pref = [
+            "rich", "real_rich", "blocked", "rich_8", "real_rich_8", "blocked_8",
+            "block_dct_8", "block_bd_pca_8", "block_fft_8",
+        ]
+        global_methods_pref = ["qft", "entangled_qft", "tebd", "mera",
+                               "dct4_ctl", "bd_pca", "dct", "fft"]
+        methods = ([m for m in block_methods_pref if m in available]
+                   + [m for m in global_methods_pref if m in available])
+    # Learned (trained) bases get one header colour, classical baselines another.
+    trained_names = set(trained)
     n_methods = len(methods)
     n_cols = 1 + n_methods
     n_rows = len(keep_ratios)
@@ -238,7 +254,14 @@ def main():
     fig_w = n_cols * cell + 0.55
     fig_h = n_rows * cell + 0.55
 
-    headers = ["original"] + methods
+    # Pretty column labels matching the paper's results table (\cref{tab:div2k_repr}).
+    header_labels = {
+        "rich": "RichBasis", "real_rich": "RichBasis",
+        "dct4_ctl": "DCT-IV", "qft": "QFT", "entangled_qft": "Entangled QFT",
+        "tebd": "TEBD", "mera": "MERA",
+        "block_dct_8": "block DCT 8$\\times$8", "block_fft_8": "block DFT 8$\\times$8",
+    }
+    headers = ["original"] + [header_labels.get(m, m) for m in methods]
 
     out_base = Path(args.out)
     img_lookup = dict(zip(image_labels, images))
@@ -253,12 +276,12 @@ def main():
         # Figure-level title intentionally omitted — captions live in the paper.
 
         for c, h in enumerate(headers):
-            if 1 <= c <= len(block_methods):
-                color = "#0a3d8c"
-            elif c > len(block_methods):
-                color = "#666666"
-            else:
+            if c == 0:
                 color = "black"
+            elif methods[c - 1] in trained_names:
+                color = "#0a3d8c"
+            else:
+                color = "#666666"
             axes[0, c].set_title(h, fontsize=6.5, color=color, pad=2)
 
         for r_idx, kr in enumerate(keep_ratios):
@@ -314,12 +337,12 @@ def main():
         )
         # Figure-level title intentionally omitted — captions live in the paper.
         for c, h in enumerate(headers):
-            if 1 <= c <= len(block_methods):
-                color = "#0a3d8c"
-            elif c > len(block_methods):
-                color = "#666666"
-            else:
+            if c == 0:
                 color = "black"
+            elif methods[c - 1] in trained_names:
+                color = "#0a3d8c"
+            else:
+                color = "#666666"
             axes_f[c].set_title(h, fontsize=6.5, color=color, pad=2)
 
         # Col 0 = original image (gray), cols 1.. = freq spectra (viridis)

--- a/tools/render_paper_compression_rd.py
+++ b/tools/render_paper_compression_rd.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Render the paper's §5.2 QuickDraw rate-distortion figure.
+
+A single-column, paper-styled variant of ``render_compression_rd.py``. The
+x-axis is compressed size as a percentage of the raw image, so the two reference
+rules -- a horizontal cut at 35 dB and a vertical rule at 40% of raw -- both land
+on grid lines and read as clean crosshairs. The crossings are marked with values:
+the compressed size (%) each basis needs to reach 35 dB (horizontal), and each
+basis's test PSNR at 40% of raw (vertical). 40% is used for the vertical reading
+because both curves are well-sampled there, so the points sit on the grid line
+and on the curves; the 50%-of-raw budget floats the block-DCT point off the line.
+
+Reads results/training/6_dataset_compression/quickdraw_5q/{rd_curves,headline_50pct}.json.
+Writes figures/rd_quickdraw_paper.{pdf,svg} in that dataset dir. Copy the PDF into
+the paper at figures/benchmarks/compression/rd_quickdraw.pdf.
+
+Style per CLAUDE.md: Wong palette, one colour + one line style per basis,
+linear axes, no figure-level title, PDF+SVG only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+matplotlib.rcParams["pdf.fonttype"] = 42  # avoid Type-3 (arXiv flags it)
+matplotlib.rcParams["ps.fonttype"] = 42
+import numpy as np
+import matplotlib.pyplot as plt
+
+BASE_DIR = Path("results/training/6_dataset_compression")
+DDIR = BASE_DIR / "quickdraw_5q"
+
+BLUE, GREEN = "#0072B2", "#009E73"  # Wong palette
+PSNR_CUT = 35.0                     # fixed-PSNR horizontal reading (dB)
+V_PCT = 40.0                        # fixed-size vertical reading (% of raw)
+
+
+def pareto(points):
+    """Max-PSNR frontier: sort by bytes, keep points that improve PSNR."""
+    pts = sorted(points, key=lambda p: p["bytes_per_image"])
+    front, best = [], -1e9
+    for p in pts:
+        if p["test"]["mean_psnr"] > best:
+            best = p["test"]["mean_psnr"]
+            front.append(p)
+    return front
+
+
+def bytes_at_psnr(front, target):
+    """Linear-interpolate bytes/image needed to reach a target PSNR."""
+    xs = [p["bytes_per_image"] for p in front]
+    ys = [p["test"]["mean_psnr"] for p in front]
+    return float(np.interp(target, ys, xs))
+
+
+def psnr_at_bytes(front, target_bytes):
+    """Linear-interpolate PSNR at a target bytes/image."""
+    xs = [p["bytes_per_image"] for p in front]
+    ys = [p["test"]["mean_psnr"] for p in front]
+    return float(np.interp(target_bytes, xs, ys))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default=None,
+                    help="optional extra path to also write the PDF to "
+                         "(e.g. the paper's figures/benchmarks/compression/rd_quickdraw.pdf)")
+    args = ap.parse_args()
+
+    rd = json.loads((DDIR / "rd_curves.json").read_text())
+    curves, meta = rd["curves"], rd["meta"]
+    raw_bpi = meta["raw_bytes_per_image"]
+
+    rich = pareto(curves["real_rich"])
+    dct = pareto(curves["block_dct_8"])
+
+    # Fixed-PSNR reading: bytes/image at PSNR_CUT.
+    x_rich = bytes_at_psnr(rich, PSNR_CUT)
+    x_dct = bytes_at_psnr(dct, PSNR_CUT)
+    saved_pct = 100.0 * (1.0 - x_rich / x_dct)
+
+    # Fixed-size vertical reading at 40% of raw -- a clean grid point where both
+    # curves are well-sampled, so the two points land on the x=40 grid line and
+    # on their curves (the 50% budget floats the block-DCT marker off the line,
+    # since its best in-budget config sits near 47%).
+    v_bytes = V_PCT / 100.0 * raw_bpi
+    y_rich = psnr_at_bytes(rich, v_bytes)
+    y_dct = psnr_at_bytes(dct, v_bytes)
+    d_psnr = y_rich - y_dct
+
+    print(f"QuickDraw @ {PSNR_CUT:.0f} dB:  rich={x_rich:.0f} B/img  "
+          f"dct={x_dct:.0f} B/img  -> {saved_pct:.1f}% fewer bytes")
+    print(f"QuickDraw @ {V_PCT:.0f}%-of-raw:  rich={y_rich:.2f} dB  "
+          f"dct={y_dct:.2f} dB  -> +{d_psnr:.2f} dB")
+
+    fig, ax = plt.subplots(figsize=(3.5, 3.0))
+
+    # x-axis is the mean compressed size expressed as a percentage of the raw
+    # image size, so the 50%-of-raw budget lands exactly on a grid line.
+    pct = lambda b: 100.0 * b / raw_bpi
+
+    ax.plot([pct(p["bytes_per_image"]) for p in rich],
+            [p["test"]["mean_psnr"] for p in rich],
+            color=BLUE, linestyle="-", marker="o", markersize=4,
+            linewidth=2.0, label="RichBasis (trained)", zorder=3)
+    ax.plot([pct(p["bytes_per_image"]) for p in dct],
+            [p["test"]["mean_psnr"] for p in dct],
+            color=GREEN, linestyle="-.", marker="s", markersize=3.5,
+            linewidth=2.0, label=r"block DCT 8$\times$8", zorder=3)
+
+    # Grid-aligned reference lines: the 35 dB quality (horizontal) and the
+    # 40%-of-raw size (vertical). With the % x-axis both fall on grid lines
+    # (y=35, x=40), so they read as clean crosshairs rather than free rules.
+    ax.axhline(PSNR_CUT, color="0.55", linestyle=(0, (5, 3)), linewidth=1.1,
+               zorder=1)
+    ax.axvline(V_PCT, color="0.55", linestyle=(0, (5, 3)), linewidth=1.1,
+               zorder=1)
+    ax.text(pct(100), PSNR_CUT + 0.5, "35 dB", fontsize=8, color="0.3",
+            ha="left", va="bottom")
+    ax.annotate(f"{V_PCT:.0f}% of raw", xy=(V_PCT, 20.5), xytext=(-4, 0),
+                textcoords="offset points", fontsize=8, rotation=90,
+                ha="right", va="center", color="0.25",
+                bbox=dict(boxstyle="round,pad=0.12", facecolor="white",
+                          edgecolor="none", alpha=0.85))
+
+    # Horizontal reading -- compressed size (% of raw) where each curve reaches
+    # 35 dB. RichBasis reaches it at a smaller size; the two numbers are marked.
+    xr, xd = pct(x_rich), pct(x_dct)
+    ax.plot([xr, xd], [PSNR_CUT, PSNR_CUT], marker="o", markersize=4.5,
+            linestyle="none", markerfacecolor="white", markeredgecolor="black",
+            markeredgewidth=1.0, zorder=6)
+    ax.annotate(f"{xr:.0f}%", xy=(xr, PSNR_CUT), xytext=(-11, -6),
+                textcoords="offset points", ha="right", va="top",
+                fontsize=8, color=BLUE)
+    ax.annotate(f"{xd:.0f}%", xy=(xd, PSNR_CUT), xytext=(4, -8),
+                textcoords="offset points", ha="left", va="top",
+                fontsize=8, color=GREEN)
+
+    # Vertical reading -- test PSNR at 40% of raw. Both points sit on the x=40
+    # grid line and on their curves; same open circles as the horizontal reading,
+    # both PSNR values marked (no gap arrow -- the two values carry it).
+    ax.plot([V_PCT, V_PCT], [y_rich, y_dct], marker="o", markersize=4.5,
+            linestyle="none", markerfacecolor="white", markeredgecolor="black",
+            markeredgewidth=1.0, zorder=6)
+    ax.annotate(f"{y_rich:.1f} dB", xy=(V_PCT, y_rich), xytext=(-7, 2),
+                textcoords="offset points", ha="right", va="bottom",
+                fontsize=8, color=BLUE)
+    ax.annotate(f"{y_dct:.1f} dB", xy=(V_PCT, y_dct), xytext=(7, -2),
+                textcoords="offset points", ha="left", va="top",
+                fontsize=8, color=GREEN)
+
+    ax.set_xlabel("compressed size (% of raw)", fontsize=9)
+    ax.set_ylabel("test PSNR (dB)", fontsize=9)
+    ax.set_xlim(pct(90), pct(575))
+    ax.set_ylim(14.5, 49.5)
+    ax.set_xticks([10, 20, 30, 40, 50])
+    ax.tick_params(labelsize=8)
+    ax.legend(fontsize=7.8, frameon=False, loc="upper left")
+    ax.grid(alpha=0.25, linewidth=0.5)
+    fig.tight_layout(pad=0.4)
+
+    figdir = DDIR / "figures"
+    figdir.mkdir(parents=True, exist_ok=True)
+    pdf = figdir / "rd_quickdraw_paper.pdf"
+    fig.savefig(pdf, bbox_inches="tight")
+    fig.savefig(figdir / "rd_quickdraw_paper.svg", bbox_inches="tight")
+    print(f"wrote {pdf} (+ .svg)")
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(out, bbox_inches="tight")
+        print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/render_topology_loss.py
+++ b/tools/render_topology_loss.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Render the paper's topology-comparison loss curve (Figure 4).
+
+Absolute validation MSE vs training step for the six learned bases (RichBasis,
+DCT-IV relaxed, QFT, Entangled QFT, TEBD, MERA), read from the shared seed-42
+topology run. A plain machine-learning loss curve:
+the y-axis is the loss itself (absolute MSE), not a per-basis L/L0
+normalisation, so the floors here are the same numbers reported in the
+Val-MSE column of the main results table.
+
+The four basic variants collapse into two near-coincident pairs
+(QFT/Entangled QFT, TEBD/MERA); distinct colour + line style per basis keeps
+the overlapping members legible.
+
+Reads results/structure/div2k_8q_pca_vs_block_dct/by_basis/<basis>/loss_history/*.json.
+Writes .../figures/topology_loss_curve.{pdf,svg}. Use --out to also drop the
+PDF into the paper at figures/benchmarks/structure/topology_loss_curve.pdf.
+
+Style per CLAUDE.md: Wong palette, one colour + one line style per basis,
+linear axes, no figure-level title, PDF+SVG only. Rendered at column size so
+the fonts stay legible without LaTeX shrinking a landscape figure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+matplotlib.rcParams["pdf.fonttype"] = 42  # avoid Type-3 (arXiv flags it)
+matplotlib.rcParams["ps.fonttype"] = 42
+import numpy as np
+import matplotlib.pyplot as plt
+
+DDIR = Path("results/structure/div2k_8q_pca_vs_block_dct")
+
+# (basis key, pretty label, Wong colour, line style, marker). Ordering places
+# each near-coincident pair adjacently so the legend reads the collapse.
+# DCT-IV (relaxed) is the real-orthogonal analogue and a headline competitor to
+# RichBasis, so it sits second and gets a high-contrast black dash-dot to stand
+# apart from the unitary family's coloured curves.
+SERIES = [
+    ("rich",          "RichBasis",        "#0072B2", "-",               "o"),
+    ("dct4_ctl",      "DCT-IV (relaxed)", "#000000", (0, (3, 1, 1, 1)), "P"),
+    ("qft",           "QFT",              "#E69F00", (0, (5, 2)),       "s"),
+    ("entangled_qft", "Entangled QFT",    "#D55E00", (0, (1, 1)),       "^"),
+    ("tebd",          "TEBD",             "#009E73", (0, (5, 2)),       "D"),
+    ("mera",          "MERA",             "#56B4E9", (0, (1, 1)),       "v"),
+]
+
+
+def load_val(basis):
+    """Validation-MSE trajectory and its per-epoch training-step x-axis."""
+    f = glob.glob(str(DDIR / "by_basis" / basis / "loss_history" / "*.json"))[0]
+    j = json.loads(Path(f).read_text())
+    val = np.asarray(j["val_losses"], dtype=float)
+    steps_per_epoch = max(1, j["steps"] // max(1, j["epochs_completed"]))
+    x = (np.arange(len(val)) + 1) * steps_per_epoch
+    return x, val
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default=None,
+                    help="optional extra path to also write the PDF to (e.g. the "
+                         "paper's figures/benchmarks/structure/topology_loss_curve.pdf)")
+    args = ap.parse_args()
+
+    fig, ax = plt.subplots(figsize=(3.5, 2.7))
+
+    finals = {}
+    for basis, label, color, ls, mk in SERIES:
+        x, val = load_val(basis)
+        finals[label] = val[-1]
+        ax.plot(x, val, color=color, linestyle=ls, linewidth=1.8,
+                marker=mk, markersize=4, markevery=14, markeredgecolor="white",
+                markeredgewidth=0.4, label=label, zorder=3)
+
+    for label, v in finals.items():
+        print(f"{label:14s} final val MSE = {v:.1f}")
+
+    ax.set_xlabel("training step", fontsize=9)
+    ax.set_ylabel("validation MSE", fontsize=9)
+    ax.set_xlim(0, 1010)
+    ax.tick_params(labelsize=8)
+    ax.grid(alpha=0.25, linewidth=0.5)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.legend(fontsize=8, frameon=False, loc="upper right",
+              handlelength=2.4, labelspacing=0.3)
+    fig.tight_layout(pad=0.4)
+
+    figdir = DDIR / "figures"
+    figdir.mkdir(parents=True, exist_ok=True)
+    pdf = figdir / "topology_loss_curve.pdf"
+    fig.savefig(pdf, bbox_inches="tight")
+    fig.savefig(figdir / "topology_loss_curve.svg", bbox_inches="tight")
+    print(f"wrote {pdf} (+ .svg)")
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(out, bbox_inches="tight")
+        print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The tooling + library changes behind the paper's Figures 4–6 and the "DCT-IV (relaxed)" results-table row. **Code only** — result artifacts (trained cells, figures) are regenerable, and the final figures live in the paper repo.

- **`dct4_ctl` (relaxed DCT-IV)** — a `DCT4Basis` in the O(2)-twiddle `controlled` parametrization (exact-init), registered as a factory and exposed as an `--bases` option on both dataset entry points. Trained through `run_experiment` it logs a val-MSE trajectory comparable to the other full-image bases.
- **Loader repair (`_loading.py`)** — `load_trained_basis` read a `"type"` field the current `trained_*.json` cells no longer carry (they store a run `"key"`), so it could load *none* of them. It now accepts both serialisations, rebuilds the full-image RichBasis via the pdft class directly (the `rich` factory is block-wrapped), and supports DCT-IV.
- **Reconstruction-gallery renderer (Figure 5)** — exact `--methods` column order, table-matching headers (coloured learned vs. classical), `--by-basis-root` (discover a freshly-assembled cell tree without touching the canonical results), and `--custom-images` (render on an arbitrary picture, e.g. the exact Quick Draw cat embedded in the Figure 1 banner).
- **New renderers** — `render_topology_loss.py` (Figure 4) and `render_paper_compression_rd.py` (Figure 6).

## Test plan

- [x] All 7 files compile (`py_compile`).
- [x] `load_trained_basis` loads every DIV2K full-image cell + DCT-IV; reconstructing source #390 reproduces the table's per-basis PSNR ordering (dct4 > rich > qft = eqft > tebd = mera).
- [x] `render_freq_recon_grid.py` renders both all-8-basis galleries (DIV2K #390 façade, Quick Draw banner cat) with correct labels and DCT-IV-first order.
- [x] `render_topology_loss.py` renders Figure 4 (six learned bases; DCT-IV floor 102.2).
- [x] `render_paper_compression_rd.py` renders Figure 6.
- [ ] Full from-scratch reproduction still needs a `dct4_ctl` training run (`--bases dct4_ctl --epochs 112 --no-early-stop`) plus full-image cell assembly — not automated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)