### PR TITLE
refactor(plots): shared style module (re-apply #60 onto main)

### DIFF
--- a/src/pdft_benchmarks/plots/style.py
+++ b/src/pdft_benchmarks/plots/style.py
@@ -1,0 +1,45 @@
+"""Shared plotting style for the figure renderers under ``tools/``.
+
+A single source of truth for the three things renderers otherwise re-implement:
+the colourblind-safe Wong palette, the paper rcParams (TrueType-embedded
+fonts), and the PDF+SVG dual-save convention. Importing these keeps colours and
+output formats consistent and lets each renderer stay thin.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+
+# Colourblind-safe Wong palette (per the figure conventions in CLAUDE.md).
+WONG: dict[str, str] = {
+    "blue": "#0072B2",
+    "orange": "#E69F00",
+    "green": "#009E73",
+    "pink": "#CC79A7",
+    "vermilion": "#D55E00",
+    "sky": "#56B4E9",
+    "black": "#000000",
+}
+
+
+def set_paper_rcparams() -> None:
+    """Embed TrueType (Type-42) fonts in PDF/PS output (arXiv flags Type-3)."""
+    matplotlib.rcParams["pdf.fonttype"] = 42
+    matplotlib.rcParams["ps.fonttype"] = 42
+
+
+def save_figure(fig, base_path, *, formats=("pdf", "svg"), bbox_inches="tight"):
+    """Save ``fig`` to ``base_path`` in each format (default PDF + SVG) -- the
+    repo's figure convention (no PNG). Any suffix on ``base_path`` is replaced
+    per format, and the parent directory is created. Returns the paths written.
+    """
+    base = Path(base_path)
+    written = []
+    for fmt in formats:
+        out = base.with_suffix(f".{fmt}")
+        out.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(out, format=fmt, bbox_inches=bbox_inches)
+        written.append(out)
+    return written

--- a/tools/paper/render_ar1_examples.py
+++ b/tools/paper/render_ar1_examples.py
@@ -15,6 +15,8 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
+from pdft_benchmarks.plots.style import save_figure
+
 
 def ar1_2d(side: int, rho: float, seed: int) -> np.ndarray:
     """Sample a 2D separable AR(1)-Gaussian field of shape (side, side)."""
@@ -137,10 +139,8 @@ def main() -> None:
     fig.subplots_adjust(left=0.005, right=0.995, top=0.93, bottom=0.005)
     out = Path("results/quickdraw_pca_vs_block_dct/figures/ar1_examples.pdf")
     out.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out, bbox_inches="tight")
-    out_svg = out.with_suffix(".svg")
-    fig.savefig(out_svg, bbox_inches="tight")
-    print(f"[viz] wrote {out} + {out_svg}")
+    save_figure(fig, out)
+    print(f"[viz] wrote {out} (+ .svg)")
 
 
 if __name__ == "__main__":

--- a/tools/paper/render_loss_curves.py
+++ b/tools/paper/render_loss_curves.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import numpy as np
 
+from pdft_benchmarks.plots.style import save_figure
+
 
 DATASET_CONFIG = {
     "quickdraw": {
@@ -288,11 +290,8 @@ def main():
                mode="absolute", show_legend=True, show_title=False)
     fig.subplots_adjust(left=0.08, right=0.99, top=0.97, bottom=0.10)
 
-    out_pdf.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_pdf, bbox_inches="tight")
-    out_svg = out_pdf.with_suffix(".svg")
-    fig.savefig(out_svg, bbox_inches="tight")
-    print(f"[viz] wrote {out_pdf} + {out_svg}")
+    save_figure(fig, out_pdf)
+    print(f"[viz] wrote {out_pdf} (+ .svg)")
 
 
 if __name__ == "__main__":

--- a/tools/paper/render_paper_compression_rd.py
+++ b/tools/paper/render_paper_compression_rd.py
@@ -27,15 +27,17 @@ from pathlib import Path
 import matplotlib
 
 matplotlib.use("Agg")
-matplotlib.rcParams["pdf.fonttype"] = 42  # avoid Type-3 (arXiv flags it)
-matplotlib.rcParams["ps.fonttype"] = 42
 import numpy as np
 import matplotlib.pyplot as plt
+
+from pdft_benchmarks.plots.style import WONG, save_figure, set_paper_rcparams
+
+set_paper_rcparams()
 
 BASE_DIR = Path("results/training/6_dataset_compression")
 DDIR = BASE_DIR / "quickdraw_5q"
 
-BLUE, GREEN = "#0072B2", "#009E73"  # Wong palette
+BLUE, GREEN = WONG["blue"], WONG["green"]  # Wong palette
 PSNR_CUT = 35.0                     # fixed-PSNR horizontal reading (dB)
 V_PCT = 40.0                        # fixed-size vertical reading (% of raw)
 
@@ -167,8 +169,7 @@ def main():
     figdir = DDIR / "figures"
     figdir.mkdir(parents=True, exist_ok=True)
     pdf = figdir / "rd_quickdraw_paper.pdf"
-    fig.savefig(pdf, bbox_inches="tight")
-    fig.savefig(figdir / "rd_quickdraw_paper.svg", bbox_inches="tight")
+    save_figure(fig, pdf)
     print(f"wrote {pdf} (+ .svg)")
     if args.out:
         out = Path(args.out)

--- a/tools/paper/render_topology_loss.py
+++ b/tools/paper/render_topology_loss.py
@@ -31,10 +31,12 @@ from pathlib import Path
 import matplotlib
 
 matplotlib.use("Agg")
-matplotlib.rcParams["pdf.fonttype"] = 42  # avoid Type-3 (arXiv flags it)
-matplotlib.rcParams["ps.fonttype"] = 42
 import numpy as np
 import matplotlib.pyplot as plt
+
+from pdft_benchmarks.plots.style import WONG, save_figure, set_paper_rcparams
+
+set_paper_rcparams()
 
 DDIR = Path("results/structure/div2k_8q_pca_vs_block_dct")
 
@@ -44,12 +46,12 @@ DDIR = Path("results/structure/div2k_8q_pca_vs_block_dct")
 # RichBasis, so it sits second and gets a high-contrast black dash-dot to stand
 # apart from the unitary family's coloured curves.
 SERIES = [
-    ("rich",          "RichBasis",        "#0072B2", "-",               "o"),
-    ("dct4_ctl",      "DCT-IV (relaxed)", "#000000", (0, (3, 1, 1, 1)), "P"),
-    ("qft",           "QFT",              "#E69F00", (0, (5, 2)),       "s"),
-    ("entangled_qft", "Entangled QFT",    "#D55E00", (0, (1, 1)),       "^"),
-    ("tebd",          "TEBD",             "#009E73", (0, (5, 2)),       "D"),
-    ("mera",          "MERA",             "#56B4E9", (0, (1, 1)),       "v"),
+    ("rich",          "RichBasis",        WONG["blue"],      "-",               "o"),
+    ("dct4_ctl",      "DCT-IV (relaxed)", WONG["black"],     (0, (3, 1, 1, 1)), "P"),
+    ("qft",           "QFT",              WONG["orange"],    (0, (5, 2)),       "s"),
+    ("entangled_qft", "Entangled QFT",    WONG["vermilion"], (0, (1, 1)),       "^"),
+    ("tebd",          "TEBD",             WONG["green"],     (0, (5, 2)),       "D"),
+    ("mera",          "MERA",             WONG["sky"],       (0, (1, 1)),       "v"),
 ]
 
 
@@ -97,8 +99,7 @@ def main():
     figdir = DDIR / "figures"
     figdir.mkdir(parents=True, exist_ok=True)
     pdf = figdir / "topology_loss_curve.pdf"
-    fig.savefig(pdf, bbox_inches="tight")
-    fig.savefig(figdir / "topology_loss_curve.svg", bbox_inches="tight")
+    save_figure(fig, pdf)
     print(f"wrote {pdf} (+ .svg)")
     if args.out:
         out = Path(args.out)


### PR DESCRIPTION
## Why this exists

PR #60 was merged into the **intermediate `chore/tools-reorg` branch** *after* that branch had already been squash-merged into `main` (#59). Squash-merge collapses the branch into one new commit, so the later merge landed on an orphaned branch and **its changes never reached `main`**. On `main` today the paper renderers still carry inline hex colours and duplicated `savefig` calls.

This PR re-applies the exact same 5-file change directly on top of `main`.

## Summary

**New — `src/pdft_benchmarks/plots/style.py`:** one source of truth for the boilerplate renderers otherwise re-implement:
- `WONG` — the 7-colour colourblind-safe Wong palette.
- `save_figure(fig, base)` — PDF+SVG dual-save (the repo's figure convention).
- `set_paper_rcparams()` — TrueType (Type-42) font embedding.

**Adopted, output-preserving:**
- `render_topology_loss`, `render_paper_compression_rd` — `WONG` + `set_paper_rcparams` + `save_figure`. **Both re-render pixel-identically** (rasterise + diff).
- `render_loss_curves`, `render_ar1_examples` — `save_figure` (bespoke palettes left as-is).

## Deliberately conservative
`set_paper_rcparams()` consolidated **only where already set** — not added to renderers that lacked `fonttype=42`, since that would re-encode already-finalised figures. `analysis/` renderers can adopt the helpers incrementally.

## Test plan
- [x] Diff is exactly the 5 intended files (`style.py` + 4 renderers).
- [x] `render_topology_loss` and `render_paper_compression_rd` produce **pixel-identical** PDFs.
- [x] `render_ar1_examples` and `render_loss_curves` render cleanly to PDF+SVG.

> Note: merge this as a **normal squash to `main`**, not stacked — that's what tripped up #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)